### PR TITLE
Add Typer CLI entrypoint

### DIFF
--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,0 +1,13 @@
+import typer
+
+app = typer.Typer(help="SquirrelFocus command line interface")
+
+
+@app.command()
+def hello(name: str = "world"):
+    """Say hello to NAME."""
+    typer.echo(f"Hello {name}!")
+
+
+if __name__ == "__main__":
+    app()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,9 @@ pytest = "*"
 black = "*"
 ruff = "*"
 
+[tool.poetry.scripts]
+squirrelfocus = "cli:app"
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
## Summary
- set up a basic Typer `app` with a `hello` command
- expose the CLI via a `squirrelfocus` console script in Poetry

## Testing
- `black --check .`
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847c6cbaf8c8320a6e93d10e77c017b