### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,19 @@ developers stay focused and keep short personal notes during a work session.
 
 ## Installation
 
-Clone the repository and install the dependencies using Poetry:
+Clone the repository and install the dependencies using Poetry. Skipping the
+project package keeps the environment lightweight:
 
 ```bash
-poetry install
+poetry install --no-root
 ```
+
+You can achieve the same behavior permanently by setting
+`package-mode = false` in your Poetry configuration.
 
 ## Running the CLI
 
-After installing the project you can invoke the CLI directly:
+After installing the project you can invoke the CLI using Poetry's `run` command:
 
 ```bash
 poetry run sf hello


### PR DESCRIPTION
## Summary
- refresh install snippet to use `poetry install --no-root`
- note how to enable `package-mode = false`
- clarify CLI invocation via `poetry run`

## Testing
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847de2367b0832083aca57874e95fbf