### PR TITLE
Update CLI usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,20 @@ poetry install --no-root
 ```
 
 You can achieve the same behavior permanently by setting
-`package-mode = false` in your Poetry configuration.
+`package-mode = false` in your Poetry configuration. When skipping the
+package installation, the `sf` entry point is not available. Invoke the
+CLI module directly instead:
+
+```bash
+poetry run python -m cli hello
+```
+
+If you do install the package (or enable package mode) the original
+entry point will work as before:
+
+```bash
+poetry run sf hello
+```
 
 ## Running the CLI
 


### PR DESCRIPTION
## Summary
- clarify CLI usage when installing with `--no-root`

## Testing
- `poetry run pytest`
- `poetry run ruff .`
- `poetry run black --check .`


------
https://chatgpt.com/codex/tasks/task_e_6847e2ca7f288320bc579fabeebe836a