### PR TITLE
Add Poetry setup helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,21 @@ developers stay focused and keep short personal notes during a work session.
 ## Prerequisites
 
 - Python 3.10 or newer
-- [Poetry](https://python-poetry.org/) for dependency management
+- [Poetry](https://python-poetry.org/) for dependency management. The
+  `scripts/setup_poetry.sh` helper will install it automatically if it is
+  missing.
 
 ## Installation
 
-Clone the repository and install the dependencies using Poetry. Skipping the
-project package keeps the environment lightweight:
+Clone the repository and run the helper script. It installs Poetry if needed
+and then installs the project dependencies:
+
+```bash
+./scripts/setup_poetry.sh
+```
+
+If you prefer to manage Poetry yourself you can still run `poetry install`
+manually. Skipping the project package keeps the environment lightweight:
 
 ```bash
 poetry install --no-root

--- a/scripts/setup_poetry.sh
+++ b/scripts/setup_poetry.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -e
+
+# Ensure we're in repo root
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$REPO_ROOT"
+
+# Create a minimal pyproject if one does not exist
+if [ ! -f pyproject.toml ]; then
+    cat > pyproject.toml <<'PYEOF'
+[tool.poetry]
+name = "squirrelfocus"
+version = "0.1.0"
+description = ""
+authors = []
+
+[tool.poetry.dependencies]
+python = "^3.10"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+PYEOF
+fi
+
+# Install Poetry if it is not already available
+if ! command -v poetry >/dev/null 2>&1; then
+    echo "Poetry not found. Installing..." >&2
+    curl -sSL https://install.python-poetry.org | python3 -
+    export PATH="$HOME/.local/bin:$PATH"
+fi
+
+poetry install
+


### PR DESCRIPTION
## Summary
- add `scripts/setup_poetry.sh` to install Poetry and dependencies
- document the helper in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847e60ad60c832090b432fad19ec454