### PR TITLE
Add setup script and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,1 +1,28 @@
-# Placeholder CI script
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+          echo "PATH=$HOME/.local/bin:$PATH" >> $GITHUB_ENV
+      - name: Install dependencies
+        run: |
+          poetry install --no-root
+      - name: Run linters
+        run: |
+          poetry run ruff .
+          poetry run black --check .
+      - name: Run tests
+        run: poetry run pytest -q

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ developers stay focused and keep short personal notes during a work session.
 
 - Python 3.10 or newer
 - [Poetry](https://python-poetry.org/) for dependency management. The
-  `scripts/setup_poetry.sh` helper will install it automatically if it is
-  missing.
+  `setup.sh` helper will install it automatically if it is missing.
 
 ## Installation
 
@@ -17,7 +16,7 @@ Clone the repository and run the helper script. The script installs Poetry if
 needed and then installs the project dependencies:
 
 ```bash
-./scripts/setup_poetry.sh
+./setup.sh
 ```
 
 After the script completes run a quick greeting to verify the setup:

--- a/docs/reflections/developer_journal.md
+++ b/docs/reflections/developer_journal.md
@@ -10,8 +10,8 @@
 
 ## Usage Scenarios
 
-- Launch `squirrelfocus hello` to verify your environment before starting work.
-- Use `squirrelfocus drop "note"` to capture progress or blockers quickly.
-- Run `squirrelfocus show 5` to review recent entries and plan next tasks.
+ - Launch `sf hello` to verify your environment before starting work.
+ - Use `sf drop "note"` to capture progress or blockers quickly.
+ - Run `sf show 5` to review recent entries and plan next tasks.
 - Review these notes at the end of the day to spot patterns in focus and
   productivity.

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+
+# Ensure execution from repository root
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+./scripts/setup_poetry.sh


### PR DESCRIPTION
## Summary
- add `setup.sh` wrapper for Poetry setup
- update docs to use new setup process and CLI name
- create CI workflow using Poetry

## Testing
- `poetry run ruff .`
- `poetry run black --check .`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847f0aba4ec8320b8e6e38887a523b7