### PR TITLE
Add CLI reference docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ command:
 ```bash
 poetry run sf hello
 ```
+See [docs/cli_reference.md](docs/cli_reference.md) for command details.
 
 The default command prints a friendly greeting. Use `drop` to store a note and
 `show` to display recent entries. The `ask` command requires an

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -1,0 +1,36 @@
+# CLI Reference
+
+This file lists the available commands and examples.
+
+## hello [NAME]
+
+Print a friendly greeting. NAME defaults to "world".
+
+```bash
+poetry run sf hello
+poetry run sf hello squirrels
+```
+
+## drop TEXT
+
+Append TEXT to ~/.squirrelfocus/acornlog.txt with a timestamp.
+
+```bash
+poetry run sf drop "Fixed a tricky bug"
+```
+
+## show [COUNT]
+
+Display the last COUNT entries from the log. COUNT defaults to 5.
+
+```bash
+poetry run sf show 3
+```
+
+## ask QUESTION
+
+Create a work item from QUESTION using OpenAI. Requires OPENAI_API_KEY.
+
+```bash
+poetry run sf ask "How do I plan tomorrow?"
+```


### PR DESCRIPTION
## Summary
- document CLI commands in `docs/cli_reference.md`
- link to the new reference from README

## Testing
- `pip install typer==0.12.3 openai==1.14.1 pytest==8.2.0`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68480d863fd483209e41bfee2e279a9c