### PR TITLE
Add integration webhook format docs

### DIFF
--- a/docs/integrations/webhook_format.md
+++ b/docs/integrations/webhook_format.md
@@ -1,0 +1,25 @@
+# Webhook Format for Integrations
+
+Integrations send data to SquirrelFocus using webhooks. Each integration
+issues an HTTP POST request to the configured URL. The request body must
+be JSON encoded and include the following fields:
+
+- `source`: a short identifier such as `github`.
+- `event`: the event type that triggered the webhook.
+- `payload`: a nested object containing event details.
+
+Example payload:
+
+```json
+{
+  "source": "github",
+  "event": "push",
+  "payload": {
+    "repository": "squirrelfocus",
+    "pusher": "octocat"
+  }
+}
+```
+
+Integrations may add extra fields as needed, but the three keys above must
+always be present. The server validates them before processing the request.

--- a/integrations/Agents.md
+++ b/integrations/Agents.md
@@ -1,4 +1,4 @@
-# Integrations TODO
+# Integrations
 
-- Outline how integrations should send data.
-- Decide on webhook formats.
+See [Webhook Format](../docs/integrations/webhook_format.md) for how
+integrations send data and the expected payload structure.


### PR DESCRIPTION
## Summary
- document webhook format for integrations
- reference the new document from integration guidelines

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_684810e2384c8320995e705b4d02c8f0