### PR TITLE
Fix CLI help line length

### DIFF
--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -9,9 +9,9 @@ import typer
 
 app = typer.Typer(
     help=(
-        "SquirrelFocus command line interface. Use 'drop' to add notes and "
-        "'show' to view them. Entries are stored in "
-        "~/.squirrelfocus/acornlog.txt"
+        "SquirrelFocus command line interface. Use 'drop' to add notes"
+        " and 'show' to view them. "
+        "Entries are stored in ~/.squirrelfocus/acornlog.txt"
     )
 )
 


### PR DESCRIPTION
## Summary
- wrap CLI help text so every line stays under 79 characters

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684815fa2fdc8320bc9a4b2d839501c6