### PR TITLE
Update work item generator template

### DIFF
--- a/codex/prompts/work_item_generator.md
+++ b/codex/prompts/work_item_generator.md
@@ -1,16 +1,16 @@
 # Work Item Generator
 
 Use this template to create focused tasks from daily notes or planning
-sessions.
+sessions. Generated tasks must keep each line under 79 characters.
 
 ## Template
 
 ```
-Task: <one sentence summary>
-Details:
-- Background: <brief context>
-- Goal: <desired outcome>
-- Steps:
+Title: <short phrase summarizing the task>
+Description: <single sentence description>
+Type: <bug|feature|chore>
+Tags: <comma separated keywords>
+Steps:
   1. <first action>
   2. <next action>
   3. <final action>
@@ -18,12 +18,18 @@ Details:
 
 ## Example
 
+Input:
 ```
-Task: Add lint check to CI workflow
-Details:
-- Background: Repos lack automated style checks
-- Goal: Fail builds when ruff finds issues
-- Steps:
+Need to add automated style checks to the pipeline
+```
+
+Output:
+```
+Title: Add lint check to CI
+Description: Fail builds when ruff finds issues
+Type: feature
+Tags: ci,lint,automation
+Steps:
   1. Update CI config with ruff command
   2. Ensure ruff is installed in test env
   3. Verify pipeline fails on lint errors


### PR DESCRIPTION
## Summary
- expand work item generator with explicit fields
- document tagging example and line limit

## Testing
- `poetry run ruff check .`
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_6848e8fcb8b88320af0d3acc2e1bcd25