### PR TITLE
Fix CLI count parsing

### DIFF
--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -41,8 +41,14 @@ def drop(text: str) -> None:
 
 
 @app.command()
-def show(count: int = typer.Argument(5)) -> None:
+def show(count: str = typer.Argument("5")) -> None:
     """Print the last COUNT lines from ~/.squirrelfocus/acornlog.txt."""
+    try:
+        count_int = int(count)
+    except ValueError:
+        typer.echo("Error: COUNT must be an integer.")
+        raise typer.Exit(code=2)
+
     ensure_log_dir()
     if not LOG_FILE.exists():
         typer.echo("No log entries found.")
@@ -51,7 +57,7 @@ def show(count: int = typer.Argument(5)) -> None:
     with LOG_FILE.open("r", encoding="utf-8") as fh:
         lines = fh.readlines()
 
-    for line in lines[-count:]:
+    for line in lines[-count_int:]:
         typer.echo(line.rstrip())
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -49,7 +49,7 @@ def test_show_invalid_count(tmp_path, monkeypatch):
     setup_tmp_log(tmp_path, monkeypatch)
     result = runner.invoke(cli.app, ["show", "bad"])
     assert result.exit_code != 0
-    assert "is not a valid integer" in result.output
+    assert "COUNT must be an integer" in result.output
 
 
 class DummyCompletions:


### PR DESCRIPTION
## Summary
- handle invalid `show` count without relying on Typer's parser
- check new error message in CLI tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848efc4f6cc83208b5c838e9b0a08b0