### PR TITLE
Update CLI help to mention ask command

### DIFF
--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -9,8 +9,8 @@ import typer
 
 app = typer.Typer(
     help=(
-        "SquirrelFocus command line interface. Use 'drop' to add notes"
-        " and 'show' to view them. "
+        "SquirrelFocus CLI. Use 'drop' to add notes, "
+        "'show' to view them, 'ask' to create tasks. "
         "Entries are stored in ~/.squirrelfocus/acornlog.txt"
     )
 )

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -29,7 +29,8 @@ poetry run sf show 3
 
 ## ask QUESTION
 
-Create a work item from QUESTION using OpenAI. Requires OPENAI_API_KEY.
+Create a work item from QUESTION using OpenAI.
+The CLI help calls 'ask' to create tasks. Requires OPENAI_API_KEY.
 
 ```bash
 poetry run sf ask "How do I plan tomorrow?"


### PR DESCRIPTION
## Summary
- reference the `ask` command in the CLI help text
- explain the updated help message in the CLI reference docs

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684900f8894883208a303d6353df98a4