### PR TITLE
Validate positive count in show command

### DIFF
--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -49,6 +49,10 @@ def show(count: str = typer.Argument("5")) -> None:
         typer.echo("Error: COUNT must be an integer.")
         raise typer.Exit(code=2)
 
+    if count_int <= 0:
+        typer.echo("Error: COUNT must be greater than 0.")
+        raise typer.Exit(code=2)
+
     ensure_log_dir()
     if not LOG_FILE.exists():
         typer.echo("No log entries found.")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -58,6 +58,13 @@ def test_show_invalid_count(tmp_path, monkeypatch):
     assert "COUNT must be an integer" in result.output
 
 
+def test_show_non_positive_count(tmp_path, monkeypatch):
+    setup_tmp_log(tmp_path, monkeypatch)
+    result = runner.invoke(cli.app, ["show", "0"])
+    assert result.exit_code != 0
+    assert "greater than 0" in result.output
+
+
 class DummyCompletions:
     def create(self, model, messages):
         class DummyMessage:


### PR DESCRIPTION
## Summary
- ensure `show` fails when count <= 0
- test `show` with non-positive count

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849082855b08320b42b2580f3fb1eab