### PR TITLE
Ignore Potato files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ __pycache__/
 .env
 .ruff_cache/
 .pytest_cache/
+# Ignore Potato-related files
+Potato
+Potato.md
+Potato*


### PR DESCRIPTION
## Summary
- add ignore rules for `Potato` files

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_6849094b410483209c0958f9d343510c