### PR TITLE
Add Codex behavior doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ poetry run sf ask "How do I plan tomorrow?"
 Daily reflections live in [codex/journal](codex/journal). Each entry lists
 metadata such as date, tags and a short summary in a YAML header.
 
+See the Codex goals document
+[Codex goals](codex/goals/expected_codex_behavior.md)
+for how `sf ask` converts prompts into tasks.
+
 ## Development
 
 Common development tasks can be run through Poetry:

--- a/codex/goals/expected_codex_behavior.md
+++ b/codex/goals/expected_codex_behavior.md
@@ -1,0 +1,13 @@
+# Expected Codex Behavior
+
+This document outlines how Codex processes prompts and generates work items.
+
+## Prompt conversion with `sf ask`
+
+1. The command loads the template at
+   `codex/prompts/work_item_generator.md`.
+2. The user question is appended to the system prompt.
+3. The messages are sent to the OpenAI API.
+4. The response text becomes a work item printed to the terminal.
+
+Codex should return concise tasks that follow the template structure.


### PR DESCRIPTION
## Summary
- document how `sf ask` converts prompts into tasks
- link to the new doc from the README

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684913e1fb6c83209f1cbfa771a23a76