### PR TITLE
Improve CLI docs

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -4,7 +4,7 @@ Track outstanding work across the project.
 
 ## CLI
 
-- Document all command options.
+- Keep CLI documentation current.
 - Add tests for error cases.
 
 ## Integrations

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -1,10 +1,10 @@
 # CLI Reference
 
-This file lists the available commands and examples.
+This file lists the available commands, their options and examples.
 
 ## hello [NAME]
 
-Print a friendly greeting. NAME defaults to "world".
+Print a friendly greeting. `NAME` defaults to `"world"`.
 
 ```bash
 poetry run sf hello
@@ -13,7 +13,7 @@ poetry run sf hello squirrels
 
 ## drop TEXT
 
-Append TEXT to ~/.squirrelfocus/acornlog.txt with a timestamp.
+Append `TEXT` to `~/.squirrelfocus/acornlog.txt` with a timestamp.
 
 ```bash
 poetry run sf drop "Fixed a tricky bug"
@@ -21,17 +21,20 @@ poetry run sf drop "Fixed a tricky bug"
 
 ## show [COUNT]
 
-Display the last COUNT entries from the log. COUNT defaults to 5.
+Display the last `COUNT` entries from the log. The default is `5`.
 
 ```bash
 poetry run sf show 3
+poetry run sf show -1  # fails, COUNT must be greater than 0
 ```
 
 ## ask QUESTION
 
-Create a work item from QUESTION using OpenAI.
-The CLI help calls 'ask' to create tasks. Requires OPENAI_API_KEY.
+Create a work item from `QUESTION` using OpenAI. The CLI help calls
+`ask` to create tasks. Set the `OPENAI_API_KEY` environment variable
+before running this command.
 
 ```bash
 poetry run sf ask "How do I plan tomorrow?"
+OPENAI_API_KEY= poetry run sf ask "anything"  # prints an error
 ```


### PR DESCRIPTION
## Summary
- document all CLI options
- mention default values and negative `show` counts
- note `OPENAI_API_KEY` in examples
- update backlog item

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684915fb9a748320bc2284145468a889