### PR TITLE
Add vision and security docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,11 @@ See the Codex goals document
 [Codex goals](codex/goals/expected_codex_behavior.md)
 for how `sf ask` converts prompts into tasks.
 
+## Additional Documentation
+
+- [Vision](docs/vision.md) outlines the goals and value of the project.
+- [Security Overview](docs/security-overview.md) explains data handling.
+
 ## Development
 
 Common development tasks can be run through Poetry:

--- a/docs/corporate_review_checklist.md
+++ b/docs/corporate_review_checklist.md
@@ -1,0 +1,4 @@
+# Corporate Review Checklist
+
+- Verify that [Vision](vision.md) aligns with corporate strategy.
+- Confirm [Security Overview](security-overview.md) meets policy guidelines.

--- a/docs/security-overview.md
+++ b/docs/security-overview.md
@@ -1,0 +1,10 @@
+# Security Overview
+
+SquirrelFocus stores notes locally in plain text by default. Integrations
+can post data to webhooks, so treat credentials with care.
+
+The workflow relies on environment variables for secrets. Keep `.env`
+files out of version control and rotate API keys when needed.
+
+External services are optional. Limit access to only the features your
+team requires.

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,0 +1,10 @@
+# Project Vision
+
+SquirrelFocus helps developers capture notes and manage tasks quickly.
+The toolkit values simplicity and makes daily planning frictionless.
+
+Goals:
+
+- Provide a minimal yet flexible command line interface.
+- Store personal reflections in easy to sync text files.
+- Integrate with common tools without heavy setup.


### PR DESCRIPTION
## Summary
- describe project vision and security overview
- link docs from README
- create corporate review checklist referencing new docs

## Testing
- `poetry install --no-root`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68491fd029848320aadba92082a6f1dd