### PR TITLE
Update README with locking note

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ After the script completes run a quick greeting to verify the setup:
 poetry run sf hello
 ```
 
+If the setup complains about lock-file changes run `poetry lock` and try
+again. See [docs/troubleshooting.md](docs/troubleshooting.md) for details.
+
 If you prefer to manage Poetry yourself you can still run `poetry install`
 manually. Skipping the project package keeps the environment lightweight:
 


### PR DESCRIPTION
## Summary
- advise running `poetry lock` when setup errors mention lock-file changes
- link to the troubleshooting docs for more info

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_684924740f748320b00912a53b6a60e5