### PR TITLE
docs: detail CLI command options

### DIFF
--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -1,6 +1,7 @@
 # CLI Reference
 
-This file lists the available commands, their options and examples.
+This page lists the commands and options provided by the `sf` tool.
+Run `sf COMMAND --help` for additional details.
 
 ## hello [NAME]
 
@@ -17,22 +18,24 @@ Append `TEXT` to `~/.squirrelfocus/acornlog.txt` with a timestamp.
 
 ```bash
 poetry run sf drop "Fixed a tricky bug"
+poetry run sf drop "Wrote tests"
 ```
 
 ## show [COUNT]
 
-Display the last `COUNT` entries from the log. The default is `5`.
+Display the last `COUNT` log entries. The default is `5`.
+`COUNT` must be greater than `0`.
 
 ```bash
+poetry run sf show      # uses default of 5
 poetry run sf show 3
-poetry run sf show -1  # fails, COUNT must be greater than 0
+poetry run sf show -1   # fails with an error
 ```
 
 ## ask QUESTION
 
-Create a work item from `QUESTION` using OpenAI. The CLI help calls
-`ask` to create tasks. Set the `OPENAI_API_KEY` environment variable
-before running this command.
+Create a work item from `QUESTION` using OpenAI.
+Set the `OPENAI_API_KEY` environment variable first.
 
 ```bash
 poetry run sf ask "How do I plan tomorrow?"


### PR DESCRIPTION
## Summary
- expand CLI reference with all options and default behavior

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_684a45cf5fec8320952077d7173cfe95