### PR TITLE
docs: expand CLI command options

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ poetry run sf hello
 ```
 See [docs/cli_reference.md](docs/cli_reference.md) for command details.
 
+Shell completions are available with `--install-completion` and can be
+inspected with `--show-completion`.
+
 The default command prints a friendly greeting. Use `drop` to store a note and
 `show` to display recent entries. The `ask` command requires an
 `OPENAI_API_KEY` environment variable and turns a question into a work item:

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -3,6 +3,14 @@
 This page lists the commands and options provided by the `sf` tool.
 Run `sf COMMAND --help` for additional details.
 
+## Global options
+
+The CLI offers a few flags in addition to its subcommands:
+
+- `--install-completion` installs shell completion for the current shell.
+- `--show-completion` prints the completion script to standard output.
+- `--help` displays usage information for the selected command.
+
 ## hello [NAME]
 
 Print a friendly greeting. `NAME` defaults to `"world"`.


### PR DESCRIPTION
## Summary
- list global options in CLI reference
- mention shell completions in README

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a5131119c832088c7eb6a063c53ba