### PR TITLE
Scope workflow triggers and add release publishing

### DIFF
--- a/.github/workflows/ai-build.yml
+++ b/.github/workflows/ai-build.yml
@@ -1,8 +1,12 @@
 name: AI Build
 
 on:
+  push:
+    branches: [main, development]
   pull_request:
+    branches: [main, development]
   issues:
+    types: [opened, edited, reopened]
 
 jobs:
   automate:

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -2,7 +2,9 @@ name: Codex Summary
 
 on:
   pull_request:
+    branches: [main, development]
   issues:
+    types: [opened, edited, reopened]
 
 jobs:
   summarize:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,19 @@
+name: Release Publish
+on:
+  push:
+    tags: ["v*"]
+jobs:
+  publish:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.12" }
+      - run: pip install poetry==1.8.3
+      - run: poetry install --no-root --no-interaction
+      - run: poetry build
+      - env:
+          PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          poetry config pypi-token.pypi "$PYPI_API_TOKEN"
+          poetry publish


### PR DESCRIPTION
## Summary
- limit AI Build and Codex workflows to main and development branches
- add a Release Publish workflow to build and publish tagged releases

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b2b36fbabc832096a54b306eba6cff