### PR TITLE
Scope CI workflows and document branching

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,10 +2,12 @@ Target:
  - feature/fix → development
  - release → main
 
-### What changed
+### Summary
 
 ### Why
 
 ### Proof
+
+<!-- Link related journal entry when available -->
 
 ### Fix trailers (auto-appended in commits)

--- a/.github/workflows/ai-build.yml
+++ b/.github/workflows/ai-build.yml
@@ -2,6 +2,7 @@ name: AI Build
 
 on:
   pull_request:
+    branches: [main, development]
   issues:
 
 jobs:

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -2,6 +2,7 @@ name: Codex Summary
 
 on:
   pull_request:
+    branches: [main, development]
   issues:
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ __pycache__/
 .env
 .ruff_cache/
 .pytest_cache/
+# SquirrelFocus artifacts
+journal_logs/
+.git/hooks/commit-msg

--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ developers stay focused and keep short personal notes during a work session.
 
 Workflow: feature → development → main (release, tag).
 
+## Branching and CI
+
+All work starts on short-lived feature branches that merge into `development`.
+Release branches target `main`. Commits use a commit-msg hook to append
+SquirrelFocus trailers, enabling workflows to summarize the latest
+`journal_logs` entry. CI runs on pushes and pull requests for `development`
+and `main`, and merging to `main` appends a line to `MILESTONE_LOG.md`.
+
 ## Prerequisites
 
 - Python 3.10 or newer


### PR DESCRIPTION
## Summary
- limit Codex and AI Build workflows to main and development branches
- document SquirrelFocus branching and CI integration in README
- ignore journal logs and commit hooks, rename pull request template

## Testing
- `poetry run ruff check .`
- `poetry run black --check .`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2b7e951448320a0d94385c37cb88a