### PR TITLE
chore: release 0.2.0

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,24 @@
+name: Release Publish
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install Poetry
+        uses: abatilo/actions-poetry@v2
+      - name: Build and publish
+        env:
+          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          poetry install --no-root
+          poetry build
+          poetry publish --no-interaction

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## [0.2.0] - 2025-08-30
+
+### Added
+- Release workflow for publishing to PyPI.
+
+### Changed
+- Bumped version to 0.2.0.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "squirrelfocus"
-version = "0.1.0"
+version = "0.2.0"
 description = "Developer productivity and reflection toolkit."
 authors = ["Your Name <you@example.com>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
- bump version to 0.2.0
- add initial changelog and release publish workflow

## Testing
- `poetry run pytest -q`
- `git push` *(fails: No configured push destination)*
- `git push origin v0.2.0` *(fails: 'origin' does not appear to be a git repository)*

------
https://chatgpt.com/codex/tasks/task_e_68b2bbffd2288320a8a7b5c865256612