### PR TITLE
feat: add Windows commit hook installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Release branches target `main`. Commits use a commit-msg hook to append
 SquirrelFocus trailers, enabling workflows to summarize the latest
 `journal_logs` entry. CI runs on pushes and pull requests for `development`
 and `main`, and merging to `main` appends a line to `MILESTONE_LOG.md`.
+Run `bash scripts/install_hooks.sh` to install the hook on Unix-like
+systems. Windows users can run `pwsh scripts/install_hooks.ps1` to set up
+the hook.
 
 ## Prerequisites
 

--- a/scripts/install_hooks.ps1
+++ b/scripts/install_hooks.ps1
@@ -1,0 +1,32 @@
+#!/usr/bin/env pwsh
+$ErrorActionPreference = 'Stop'
+
+$root = git rev-parse --show-toplevel
+$hooks = Join-Path $root '.git/hooks'
+$cmdHook = Join-Path $hooks 'commit-msg.cmd'
+$psHook = Join-Path $hooks 'commit-msg.ps1'
+
+$psContent = @'
+param([string]$Path)
+
+$root = git rev-parse --show-toplevel
+try {
+  $trailers = python "$root/scripts/sqf_emit.py" trailers
+} catch {
+  $trailers = ""
+}
+if (-not $trailers) { exit 0 }
+Add-Content -Path $Path -Value ""
+Add-Content -Path $Path -Value $trailers
+'@
+
+$psContent | Set-Content -Path $psHook -Encoding UTF8
+
+$cmdContent = @'
+@echo off
+pwsh -NoProfile -ExecutionPolicy Bypass -File "%~dp0commit-msg.ps1" %*
+'@
+
+$cmdContent | Set-Content -Path $cmdHook -Encoding ASCII
+
+Write-Output 'Installed commit-msg hook.'


### PR DESCRIPTION
## Summary
- add PowerShell script to install commit-msg hook on Windows
- document how to run the Windows hook installer

## Testing
- `poetry run ruff check .`
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_68b2c4415fd48320b58a7d51b3dd9bc5