### PR TITLE
Add adopter guide for SquirrelFocus

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,23 @@
+# ADOPTERS
+
+Projects adopting SquirrelFocus should copy these files and directories:
+
+- `.squirrelfocus/config.yaml`
+- `scripts/*`
+- `templates/*`
+
+To use the reusable summary workflow, reference `sf-summary.yml`:
+
+```yaml
+jobs:
+  summarize:
+    uses: owner/squirrelfocus/.github/workflows/sf-summary.yml@main
+    with:
+      title: Example title
+```
+
+Verify the integration with a smoke test:
+
+```bash
+python scripts/sqf_emit.py summary
+```


### PR DESCRIPTION
## Summary
- document required files and directories for adopters
- explain how to include the reusable sf-summary workflow
- note a simple smoke test command

## Testing
- `pytest` *(fails: Missing argument 'TEXT' in tests/test_cli.py::test_drop_missing_text)*


------
https://chatgpt.com/codex/tasks/task_e_68b2d0bb92248320978ea62b3c180e81