### PR TITLE
chore: configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    auto-merge: true
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: daily
+    auto-merge: true


### PR DESCRIPTION
## Summary
- configure dependabot to check GitHub Actions and pip daily
- enable auto-merge for dependency updates

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b2d96b1c3083209cc5d244e4a66023