### PR TITLE
chore: enforce workflow timeouts

### DIFF
--- a/.github/workflows/ai-build.yml
+++ b/.github/workflows/ai-build.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   automate:
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
         env:
@@ -33,6 +34,7 @@ jobs:
           key: pipx-${{ runner.os }}-poetry-1.8.3
 
       - name: Install Poetry (robust, no curl | python)
+        timeout-minutes: 15
         id: poetry
         shell: bash
         env:
@@ -81,6 +83,7 @@ jobs:
 
       - name: Sync lockfile if stale
         if: steps.poetry.outputs.poetry_available == '1'
+        timeout-minutes: 15
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
@@ -90,12 +93,14 @@ jobs:
 
       - name: Install dependencies
         if: steps.poetry.outputs.poetry_available == '1'
+        timeout-minutes: 15
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: poetry install --no-root --no-interaction
 
       - name: Check click and typer versions
         if: steps.poetry.outputs.poetry_available == '1'
+        timeout-minutes: 15
         run: |
           poetry run python - <<'PY'
           import click, typer
@@ -104,6 +109,7 @@ jobs:
 
       - name: Run sf ask
         if: steps.poetry.outputs.poetry_available == '1'
+        timeout-minutes: 15
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           QUESTION: >-
@@ -112,6 +118,7 @@ jobs:
 
       - name: Fallback without Poetry (non-fatal)
         if: steps.poetry.outputs.poetry_available != '1'
+        timeout-minutes: 15
         continue-on-error: true
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/ci-summary.yml
+++ b/.github/workflows/ci-summary.yml
@@ -11,16 +11,19 @@ permissions:
 jobs:
   summarize:
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       - name: Install PyYAML
+        timeout-minutes: 15
         run: |
           python -m pip install --upgrade pip
           pip install "PyYAML>=6,<7"
       - name: Emit CI Summary
+        timeout-minutes: 15
         run: |
           python3 scripts/sqf_emit.py summary > summary.md || true
           if [ -s summary.md ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
@@ -34,6 +35,7 @@ jobs:
           key: pipx-${{ runner.os }}-poetry-1.8.3
 
       - name: Install Poetry (robust, no curl | python)
+        timeout-minutes: 15
         id: poetry
         shell: bash
         env:
@@ -81,6 +83,7 @@ jobs:
 
       - name: Poetry lock
         if: steps.poetry.outputs.poetry_available == '1'
+        timeout-minutes: 15
         shell: bash
         run: |
           set -euo pipefail
@@ -89,10 +92,12 @@ jobs:
 
       - name: Install dependencies
         if: steps.poetry.outputs.poetry_available == '1'
+        timeout-minutes: 15
         run: poetry install --no-root --no-interaction
 
       - name: Check click and typer versions
         if: steps.poetry.outputs.poetry_available == '1'
+        timeout-minutes: 15
         run: |
           poetry run python - <<'PY'
           import click, typer
@@ -101,16 +106,19 @@ jobs:
 
       - name: Run linters
         if: steps.poetry.outputs.poetry_available == '1'
+        timeout-minutes: 15
         run: |
           poetry run ruff check .
           poetry run black --check .
 
       - name: Run tests
         if: steps.poetry.outputs.poetry_available == '1'
+        timeout-minutes: 15
         run: poetry run pytest -q
 
       - name: Fallback without Poetry (non-fatal)
         if: steps.poetry.outputs.poetry_available != '1'
+        timeout-minutes: 15
         continue-on-error: true
         shell: bash
         run: |

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   summarize:
     uses: ./.github/workflows/sf-summary.yml
+    timeout-minutes: 15
     with:
       title: >-
         ${{ github.event.pull_request.title || github.event.issue.title }}

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -9,7 +9,6 @@ on:
 jobs:
   summarize:
     uses: ./.github/workflows/sf-summary.yml
-    timeout-minutes: 15
     with:
       title: >-
         ${{ github.event.pull_request.title || github.event.issue.title }}

--- a/.github/workflows/merge-log.yml
+++ b/.github/workflows/merge-log.yml
@@ -1,27 +1,31 @@
 name: Merge Log
 on:
   push:
-    branches: [main]
+    branches: [main, development]
 permissions:
   contents: write
 jobs:
   append-log:
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       - name: Install PyYAML
+        timeout-minutes: 15
         run: |
           python -m pip install --upgrade pip
           pip install "PyYAML>=6,<7"
       - name: Build log line
+        timeout-minutes: 15
         run: |
           line="- $(date -u +%F) — $(python3 scripts/sqf_emit.py \
             trailers | tr '\n' '; ')"
           echo "$line" >> MILESTONE_LOG.md
       - name: Commit log
+        timeout-minutes: 15
         run: |
           git config user.name "github-actions"
           git config user.email "actions@users.noreply.github.com"

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -7,20 +7,25 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
       - name: Install Poetry
+        timeout-minutes: 15
         run: pip install poetry==1.8.3
       - name: Install dependencies
+        timeout-minutes: 15
         run: poetry install --no-root --no-interaction
       - name: Build
+        timeout-minutes: 15
         run: poetry build
       - name: Publish to PyPI
         env:
           PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        timeout-minutes: 15
         run: |
           poetry config pypi-token.pypi "$PYPI_API_TOKEN"
           poetry publish --no-interaction

--- a/.github/workflows/sf-summary.yml
+++ b/.github/workflows/sf-summary.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   summarize:
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
         env:
@@ -32,6 +33,7 @@ jobs:
           key: pipx-${{ runner.os }}-poetry-1.8.3
 
       - name: Install Poetry (robust, no curl | python)
+        timeout-minutes: 15
         id: poetry
         shell: bash
         env:
@@ -80,6 +82,7 @@ jobs:
 
       - name: Sync lockfile if stale
         if: steps.poetry.outputs.poetry_available == '1'
+        timeout-minutes: 15
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
@@ -89,12 +92,14 @@ jobs:
 
       - name: Install dependencies
         if: steps.poetry.outputs.poetry_available == '1'
+        timeout-minutes: 15
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: poetry install --no-root --no-interaction
 
       - name: Check click and typer versions
         if: steps.poetry.outputs.poetry_available == '1'
+        timeout-minutes: 15
         run: |
           poetry run python - <<'PY'
           import click, typer
@@ -103,6 +108,7 @@ jobs:
 
       - name: Generate summary
         if: steps.poetry.outputs.poetry_available == '1'
+        timeout-minutes: 15
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           TITLE: ${{ inputs.title }}
@@ -110,6 +116,7 @@ jobs:
 
       - name: Fallback without Poetry (non-fatal)
         if: steps.poetry.outputs.poetry_available != '1'
+        timeout-minutes: 15
         continue-on-error: true
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
## Summary
- add 15-minute job and step timeouts across workflows
- run merge log workflow on development branch

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b776c97d888320b00555125f089a0c