### PR TITLE
Simplify show count argument

### DIFF
--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -41,18 +41,12 @@ def drop(text: str) -> None:
 
 
 @app.command()
-def show(count: str = typer.Argument("5")) -> None:
+def show(
+    count: int = typer.Argument(
+        5, min=1, help="Number of log lines to display"
+    )
+) -> None:
     """Print the last COUNT lines from ~/.squirrelfocus/acornlog.txt."""
-    try:
-        count_int = int(count)
-    except ValueError:
-        typer.echo("Error: COUNT must be an integer.")
-        raise typer.Exit(code=2)
-
-    if count_int <= 0:
-        typer.echo("Error: COUNT must be greater than 0.")
-        raise typer.Exit(code=2)
-
     ensure_log_dir()
     if not LOG_FILE.exists():
         typer.echo("No log entries found.")
@@ -61,7 +55,7 @@ def show(count: str = typer.Argument("5")) -> None:
     with LOG_FILE.open("r", encoding="utf-8") as fh:
         lines = fh.readlines()
 
-    for line in lines[-count_int:]:
+    for line in lines[-count:]:
         typer.echo(line.rstrip())
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -55,14 +55,14 @@ def test_show_invalid_count(tmp_path, monkeypatch):
     setup_tmp_log(tmp_path, monkeypatch)
     result = runner.invoke(cli.app, ["show", "bad"])
     assert result.exit_code != 0
-    assert "COUNT must be an integer" in result.output
+    assert "Invalid value for '[COUNT]'" in result.output
 
 
 def test_show_non_positive_count(tmp_path, monkeypatch):
     setup_tmp_log(tmp_path, monkeypatch)
     result = runner.invoke(cli.app, ["show", "0"])
     assert result.exit_code != 0
-    assert "greater than 0" in result.output
+    assert "range x>=1" in result.output
 
 
 class DummyCompletions:


### PR DESCRIPTION
## Summary
- accept `count` as an integer argument with a minimum of 1
- drop manual `count` parsing and associated errors
- adjust CLI tests for new argument behavior

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b792ad45a08320a0bd5cde45a717dd