### PR TITLE
Require PyYAML at runtime and document fallback

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -14,3 +14,9 @@ poetry install
 
 The first command regenerates the lock file. The second installs your
 dependencies again.
+
+## PyYAML missing at runtime
+
+`scripts/sqf_emit.py` uses PyYAML to parse config files.
+If the library is not installed the script falls back to a basic parser.
+Nested YAML structures are ignored, so install PyYAML to get full support.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -20,3 +20,4 @@ dependencies again.
 `scripts/sqf_emit.py` uses PyYAML to parse config files.
 If the library is not installed the script falls back to a basic parser.
 Nested YAML structures are ignored, so install PyYAML to get full support.
+

--- a/poetry.lock
+++ b/poetry.lock
@@ -637,7 +637,7 @@ version = "6.0.2"
 description = "YAML parser and emitter for Python"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "PyYAML-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086"},
     {file = "PyYAML-6.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf"},
@@ -879,4 +879,4 @@ typing-extensions = ">=4.12.0"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "12c6424ed792ed7ac81a258da7108bdb406fd1530a2433a9a11e36f2a339ca6c"
+content-hash = "f96a1e966283a22cfb2c1eaebf07cae694ab8693facd8a934a8781ac5d26d941"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,12 +10,12 @@ python = "^3.10"
 typer = "^0.12.3"
 openai = "^1.14.1"
 click = ">=8.1.7,<8.2"
+pyyaml = "^6.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.2.0"
 black = "^24.3.0"
 ruff = "^0.4.0"
-pyyaml = "^6.0"
 
 [tool.poetry.scripts]
 sf = "cli:app"


### PR DESCRIPTION
## Summary
- move PyYAML from dev to runtime dependencies
- document optional PyYAML fallback in troubleshooting guide
- refresh Poetry lock file

## Testing
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b79a99bd1c8320a915137cbdecd84b