### PR TITLE
feat: add math commands

### DIFF
--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -340,6 +340,33 @@ def ask(question: str) -> None:
 
 
 @app.command()
+def add(a: float, b: float) -> None:
+    """Print the sum of A and B."""
+    typer.echo(a + b)
+
+
+@app.command()
+def subtract(a: float, b: float) -> None:
+    """Print the result of A minus B."""
+    typer.echo(a - b)
+
+
+@app.command()
+def multiply(a: float, b: float) -> None:
+    """Print the product of A and B."""
+    typer.echo(a * b)
+
+
+@app.command()
+def divide(a: float, b: float) -> None:
+    """Print the result of A divided by B."""
+    if b == 0:
+        typer.echo("Cannot divide by zero.")
+        raise typer.Exit(code=1)
+    typer.echo(a / b)
+
+
+@app.command()
 def hello(name: str = typer.Argument("world")):
     """Say hello to NAME."""
     typer.echo(f"Hello {name}!")

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -49,3 +49,37 @@ Set the `OPENAI_API_KEY` environment variable first.
 poetry run sf ask "How do I plan tomorrow?"
 OPENAI_API_KEY= poetry run sf ask "anything"  # prints an error
 ```
+
+## add A B
+
+Print the sum of `A` and `B`.
+
+```bash
+poetry run sf add 2 3
+poetry run sf add 1 2.5
+```
+
+## subtract A B
+
+Print the result of `A - B`.
+
+```bash
+poetry run sf subtract 5 2
+```
+
+## multiply A B
+
+Print the product of `A` and `B`.
+
+```bash
+poetry run sf multiply 3 4
+```
+
+## divide A B
+
+Print the result of `A / B`. Fails if `B` is `0`.
+
+```bash
+poetry run sf divide 6 3
+poetry run sf divide 1 0  # prints an error
+```

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -200,3 +200,27 @@ def test_ask_prompt_missing_file(monkeypatch, tmp_path):
     result = runner.invoke(cli.app, ["ask", "hi"])
     assert result.exit_code != 0
     assert isinstance(result.exception, FileNotFoundError)
+
+
+def test_add_help():
+    result = runner.invoke(cli.app, ["add", "--help"])
+    assert result.exit_code == 0
+    assert "sum of A and B" in result.output
+
+
+def test_add_missing_argument():
+    result = runner.invoke(cli.app, ["add", "1"])
+    assert result.exit_code != 0
+    assert "Missing argument 'B'" in result.output
+
+
+def test_divide_by_zero():
+    result = runner.invoke(cli.app, ["divide", "1", "0"])
+    assert result.exit_code != 0
+    assert "Cannot divide by zero." in result.output
+
+
+def test_multiply_help():
+    result = runner.invoke(cli.app, ["multiply", "--help"])
+    assert result.exit_code == 0
+    assert "product of A and B" in result.output


### PR DESCRIPTION
## Summary
- add arithmetic helper commands to CLI
- document math commands with usage examples
- test math commands for help output and failures

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b833278d8c83209d803c96323c05d7