### PR TITLE
feat(cli): add report command

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,13 @@ The default command prints a friendly greeting. Use `drop` to store a note and
 poetry run sf drop "Fixed a tricky bug"
 poetry run sf show 3
 poetry run sf ask "How do I plan tomorrow?"
+poetry run sf report
+poetry run sf report --since 7 --format txt
 ```
+
+Use `report` to aggregate recent journal entries. The command looks back
+30 days by default. Adjust the range with `--since DAYS` and select plain
+text with `--format txt`.
 
 ## Codex Journal
 

--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -324,7 +324,8 @@ def report(
     fmt: str = typer.Option(
         "md",
         "--format",
-        click_type=click.Choice(["md", "txt"], case_sensitive=False),
+        parser=lambda v: click.Choice(["md", "txt"], case_sensitive=False)
+        .convert(v, None, None),
         help="Output format: md or txt.",
     ),
 ) -> None:

--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 import sys
 
+import click
 import openai
 import typer
 
@@ -317,9 +318,14 @@ def doctor() -> None:
 
 @app.command()
 def report(
-    since: int = typer.Option(30, "--since", help="Days back to include."),
+    since: int = typer.Option(
+        30, "--since", min=0, help="Days back to include."
+    ),
     fmt: str = typer.Option(
-        "md", "--format", help="Output format: md or txt."
+        "md",
+        "--format",
+        click_type=click.Choice(["md", "txt"], case_sensitive=False),
+        help="Output format: md or txt.",
     ),
 ) -> None:
     """Aggregate journal entries.
@@ -328,9 +334,6 @@ def report(
       --since DAYS   Include entries from the last DAYS days.
       --format TEXT  Output format: md or txt.
     """
-    if fmt not in {"md", "txt"}:
-        typer.echo("Invalid format. Use 'md' or 'txt'.")
-        raise typer.Exit(code=1)
     cfg = load_cfg()
     jdir = Path(cfg.get("journals_dir", "journal_logs"))
     if not jdir.exists():

--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -347,8 +347,7 @@ def report(
         if not date_str:
             continue
         try:
-            dt = datetime.fromisoformat(str(date_str)).date()
-        except Exception:
+        except ValueError:
             continue
         if dt < cutoff:
             continue

--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -324,8 +324,9 @@ def report(
     fmt: str = typer.Option(
         "md",
         "--format",
-        parser=lambda v: click.Choice(["md", "txt"], case_sensitive=False)
-        .convert(v, None, None),
+        parser=lambda v: click.Choice(
+            ["md", "txt"], case_sensitive=False
+        ).convert(v, None, None),
         help="Output format: md or txt.",
     ),
 ) -> None:

--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -339,7 +339,7 @@ def report(
     jdir = Path(cfg.get("journals_dir", "journal_logs"))
     if not jdir.exists():
         typer.echo("No entries found.")
-        raise typer.Exit()
+        raise typer.Exit(code=1)
     cutoff = datetime.now().date() - timedelta(days=since)
     entries: list[tuple[datetime, str, dict]] = []
     for path in sorted(jdir.glob("**/*.md")):
@@ -358,7 +358,7 @@ def report(
         entries.append((dt, title, trailers))
     if not entries:
         typer.echo("No entries found.")
-        raise typer.Exit()
+        raise typer.Exit(code=1)
     lines: list[str] = []
     for dt, title, trailers in sorted(entries):
         header = f"{dt} {title}"

--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -7,9 +7,9 @@ import shutil
 import subprocess
 import sys
 
-import click
 import openai
 import typer
+import click
 
 try:  # optional
     import yaml
@@ -324,9 +324,7 @@ def report(
     fmt: str = typer.Option(
         "md",
         "--format",
-        parser=lambda v: click.Choice(
-            ["md", "txt"], case_sensitive=False
-        ).convert(v, None, None),
+        click_type=click.Choice(["md", "txt"], case_sensitive=False),
         help="Output format: md or txt.",
     ),
 ) -> None:

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -40,6 +40,18 @@ poetry run sf show 3
 poetry run sf show -1   # fails with an error
 ```
 
+## report [--since DAYS] [--format {md,txt}]
+
+Aggregate journal entries from the past `DAYS` days. The default is `30`.
+`--format` selects Markdown (`md`) or plain text (`txt`).
+
+```bash
+poetry run sf report
+poetry run sf report --since 7
+poetry run sf report --format txt
+poetry run sf report --format html  # prints an error
+```
+
 ## ask QUESTION
 
 Create a work item from `QUESTION` using OpenAI.

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -15,7 +15,7 @@ class FixedDate(datetime):
 def make_entry(path: Path, date: str, fix: str) -> None:
     path.write_text(
         "---\n"
-        f"created_at: \"{date}\"\n"
+        f'created_at: "{date}"\n'
         "trailers:\n"
         f"  fix: {fix}\n"
         "---\n"
@@ -104,4 +104,3 @@ def test_report_empty_journal_dir(monkeypatch):
         res = runner.invoke(cli.app, ["report"])
         assert res.exit_code == 1
         assert "No entries found." in res.output
-

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -89,7 +89,7 @@ def test_report_missing_journal_dir(monkeypatch):
         )
         monkeypatch.setattr(cli, "datetime", FixedDate)
         res = runner.invoke(cli.app, ["report"])
-        assert res.exit_code == 0
+        assert res.exit_code == 1
         assert "No entries found." in res.output
 
 
@@ -102,6 +102,6 @@ def test_report_empty_journal_dir(monkeypatch):
         Path("journal_logs").mkdir()
         monkeypatch.setattr(cli, "datetime", FixedDate)
         res = runner.invoke(cli.app, ["report"])
-        assert res.exit_code == 0
+        assert res.exit_code == 1
         assert "No entries found." in res.output
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+from datetime import datetime
+from typer.testing import CliRunner
+import cli
+
+runner = CliRunner()
+
+
+class FixedDate(datetime):
+    @classmethod
+    def now(cls, tz=None):  # noqa: D401
+        return cls(2024, 2, 1)
+
+
+def make_entry(path: Path, date: str, fix: str) -> None:
+    path.write_text(
+        "---\n"
+        f"created_at: \"{date}\"\n"
+        "trailers:\n"
+        f"  fix: {fix}\n"
+        "---\n"
+    )
+
+
+def test_report_filters_and_format(monkeypatch):
+    with runner.isolated_filesystem():
+        Path(".squirrelfocus").mkdir()
+        Path(".squirrelfocus/config.yaml").write_text(
+            "journals_dir: journal_logs\n"
+        )
+        jdir = Path("journal_logs")
+        jdir.mkdir()
+        make_entry(jdir / "2024-01-15-recent.md", "2024-01-15", "bug1")
+        make_entry(jdir / "2023-12-01-old.md", "2023-12-01", "bug2")
+        monkeypatch.setattr(cli, "datetime", FixedDate)
+        res = runner.invoke(cli.app, ["report"])
+        assert res.exit_code == 0
+        assert "bug1" in res.output
+        assert "bug2" not in res.output
+        res = runner.invoke(
+            cli.app, ["report", "--since", "100", "--format", "txt"]
+        )
+        assert res.exit_code == 0
+        assert "bug2" in res.output
+        assert "###" not in res.output
+
+
+def test_report_invalid_format(monkeypatch):
+    with runner.isolated_filesystem():
+        Path(".squirrelfocus").mkdir()
+        Path(".squirrelfocus/config.yaml").write_text(
+            "journals_dir: journal_logs\n"
+        )
+        Path("journal_logs").mkdir()
+        monkeypatch.setattr(cli, "datetime", FixedDate)
+        res = runner.invoke(cli.app, ["report", "--format", "html"])
+        assert res.exit_code != 0
+        assert "Invalid format" in res.output
+

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -55,5 +55,37 @@ def test_report_invalid_format(monkeypatch):
         monkeypatch.setattr(cli, "datetime", FixedDate)
         res = runner.invoke(cli.app, ["report", "--format", "html"])
         assert res.exit_code != 0
-        assert "Invalid format" in res.output
+        assert "Invalid value for '--format'" in res.output
+
+
+def test_report_negative_since():
+    with runner.isolated_filesystem():
+        res = runner.invoke(cli.app, ["report", "--since", "-1"])
+        assert res.exit_code != 0
+        assert "Invalid value for '--since'" in res.output
+
+
+def test_report_missing_journal_dir(monkeypatch):
+    with runner.isolated_filesystem():
+        Path(".squirrelfocus").mkdir()
+        Path(".squirrelfocus/config.yaml").write_text(
+            "journals_dir: journal_logs\n"
+        )
+        monkeypatch.setattr(cli, "datetime", FixedDate)
+        res = runner.invoke(cli.app, ["report"])
+        assert res.exit_code == 0
+        assert "No entries found." in res.output
+
+
+def test_report_empty_journal_dir(monkeypatch):
+    with runner.isolated_filesystem():
+        Path(".squirrelfocus").mkdir()
+        Path(".squirrelfocus/config.yaml").write_text(
+            "journals_dir: journal_logs\n"
+        )
+        Path("journal_logs").mkdir()
+        monkeypatch.setattr(cli, "datetime", FixedDate)
+        res = runner.invoke(cli.app, ["report"])
+        assert res.exit_code == 0
+        assert "No entries found." in res.output
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from datetime import datetime
+import re
 from typer.testing import CliRunner
 import cli
 
@@ -54,15 +55,17 @@ def test_report_invalid_format(monkeypatch):
         Path("journal_logs").mkdir()
         monkeypatch.setattr(cli, "datetime", FixedDate)
         res = runner.invoke(cli.app, ["report", "--format", "html"])
+        out = re.sub(r"\x1b\[[0-9;]*m", "", res.output)
         assert res.exit_code == 2
-        assert "Invalid value for '--format'" in res.output
+        assert "Invalid value for '--format'" in out
 
 
 def test_report_negative_since():
     with runner.isolated_filesystem():
         res = runner.invoke(cli.app, ["report", "--since", "-1"])
+        out = re.sub(r"\x1b\[[0-9;]*m", "", res.output)
         assert res.exit_code == 2
-        assert "Invalid value for '--since'" in res.output
+        assert "Invalid value for '--since'" in out
 
 
 def test_report_format_case_insensitive(monkeypatch):


### PR DESCRIPTION
## Summary
- add `report` command to aggregate journal entries
- document report options in README and CLI reference
- test report aggregation and invalid flag usage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b981596a5c83209799e635d1b90233