### PR TITLE
refactor: inject datetime provider for report

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,13 @@ The default command prints a friendly greeting. Use `drop` to store a note and
 poetry run sf drop "Fixed a tricky bug"
 poetry run sf show 3
 poetry run sf ask "How do I plan tomorrow?"
+poetry run sf report
+poetry run sf report --since 7 --format txt
 ```
+
+Use `report` to aggregate recent journal entries. The command looks back
+30 days by default. Adjust the range with `--since DAYS` and select plain
+text with `--format txt`.
 
 ## Codex Journal
 

--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -351,9 +351,7 @@ def report(
         date_str = fm.get("created_at")
         if not date_str:
             continue
-        try:
-            dt = datetime.fromisoformat(str(date_str)).date()
-        except Exception:
+        except ValueError:
             continue
         if dt < cutoff:
             continue

--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 import os
 import shutil
@@ -9,6 +9,7 @@ import sys
 
 import openai
 import typer
+import click
 
 try:  # optional
     import yaml
@@ -69,10 +70,44 @@ def load_cfg() -> dict:
     return dict(DEF_CFG)
 
 
+def parse_frontmatter(text: str) -> dict:
+    """Return front matter dict parsed from TEXT."""
+    if not text.startswith("---"):
+        return {}
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        return {}
+    fm_text = parts[1]
+    if HAVE_YAML:
+        try:
+            return yaml.safe_load(fm_text) or {}
+        except Exception:
+            return {}
+    data: dict = {}
+    section: str | None = None
+    for ln in fm_text.splitlines():
+        if ln.strip().endswith(":") and not ln.startswith(" "):
+            section = ln.strip()[:-1]
+            data[section] = {}
+            continue
+        if ":" in ln:
+            k, v = ln.split(":", 1)
+            if section:
+                data[section][k.strip()] = v.strip().strip('"').strip("'")
+            else:
+                data[k.strip()] = v.strip().strip('"').strip("'")
+    return data
+
+
 def slugify(text: str) -> str:
     """Return a filesystem-safe slug for TEXT."""
     chars = [ch.lower() if ch.isalnum() else " " for ch in text]
     return "-".join("".join(chars).split())
+
+
+def _now() -> datetime:
+    """Return the current datetime."""
+    return datetime.now()
 
 
 @app.command()
@@ -284,6 +319,59 @@ def doctor() -> None:
         )
         fail = True
     raise typer.Exit(code=1 if fail else 0)
+
+
+@app.command()
+def report(
+    since: int = typer.Option(
+        30, "--since", min=0, help="Days back to include."
+    ),
+    fmt: str = typer.Option(
+        "md",
+        "--format",
+        click_type=click.Choice(["md", "txt"], case_sensitive=False),
+        help="Output format: md or txt.",
+    ),
+) -> None:
+    """Aggregate journal entries.
+
+    Options:
+      --since DAYS   Include entries from the last DAYS days.
+      --format TEXT  Output format: md or txt.
+    """
+    cfg = load_cfg()
+    jdir = Path(cfg.get("journals_dir", "journal_logs"))
+    if not jdir.exists():
+        typer.echo("No entries found.")
+        raise typer.Exit(code=1)
+    cutoff = _now().date() - timedelta(days=since)
+    entries: list[tuple[datetime, str, dict]] = []
+    for path in sorted(jdir.glob("**/*.md")):
+        fm = parse_frontmatter(path.read_text(encoding="utf-8"))
+        date_str = fm.get("created_at")
+        if not date_str:
+            continue
+        try:
+            dt = datetime.fromisoformat(str(date_str)).date()
+        except Exception:
+            continue
+        if dt < cutoff:
+            continue
+        title = fm.get("title", path.stem)
+        trailers = fm.get("trailers", {}) or {}
+        entries.append((dt, title, trailers))
+    if not entries:
+        typer.echo("No entries found.")
+        raise typer.Exit(code=1)
+    lines: list[str] = []
+    for dt, title, trailers in sorted(entries):
+        header = f"{dt} {title}"
+        lines.append(f"### {header}" if fmt == "md" else header)
+        for k, v in trailers.items():
+            prefix = "- " if fmt == "md" else ""
+            lines.append(f"{prefix}{k}: {v}")
+        lines.append("")
+    typer.echo("\n".join(lines).rstrip())
 
 
 @app.command()

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -40,6 +40,18 @@ poetry run sf show 3
 poetry run sf show -1   # fails with an error
 ```
 
+## report [--since DAYS] [--format {md,txt}]
+
+Aggregate journal entries from the past `DAYS` days. The default is `30`.
+`--format` selects Markdown (`md`) or plain text (`txt`).
+
+```bash
+poetry run sf report
+poetry run sf report --since 7
+poetry run sf report --format txt
+poetry run sf report --format html  # prints an error
+```
+
 ## ask QUESTION
 
 Create a work item from `QUESTION` using OpenAI.

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -9,7 +9,7 @@ runner = CliRunner()
 
 class FixedDate(datetime):
     @classmethod
-    def now(cls, tz=None):  # noqa: D401
+    def now(cls, tz=None):
         return cls(2024, 2, 1)
 
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,109 @@
+from pathlib import Path
+from datetime import datetime
+import re
+from typer.testing import CliRunner
+import cli
+
+runner = CliRunner()
+
+
+class FixedDate(datetime):
+    @classmethod
+    def now(cls, tz=None):  # noqa: D401
+        return cls(2024, 2, 1)
+
+
+def make_entry(path: Path, date: str, fix: str) -> None:
+    path.write_text(
+        "---\n"
+        f'created_at: "{date}"\n'
+        "trailers:\n"
+        f"  fix: {fix}\n"
+        "---\n"
+    )
+
+
+def test_report_filters_and_format(monkeypatch):
+    with runner.isolated_filesystem():
+        Path(".squirrelfocus").mkdir()
+        Path(".squirrelfocus/config.yaml").write_text(
+            "journals_dir: journal_logs\n"
+        )
+        jdir = Path("journal_logs")
+        jdir.mkdir()
+        make_entry(jdir / "2024-01-15-recent.md", "2024-01-15", "bug1")
+        make_entry(jdir / "2023-12-01-old.md", "2023-12-01", "bug2")
+        monkeypatch.setattr(cli, "_now", FixedDate.now)
+        res = runner.invoke(cli.app, ["report"])
+        assert res.exit_code == 0
+        assert "bug1" in res.output
+        assert "bug2" not in res.output
+        res = runner.invoke(
+            cli.app, ["report", "--since", "100", "--format", "txt"]
+        )
+        assert res.exit_code == 0
+        assert "bug2" in res.output
+        assert "###" not in res.output
+
+
+def test_report_invalid_format(monkeypatch):
+    with runner.isolated_filesystem():
+        Path(".squirrelfocus").mkdir()
+        Path(".squirrelfocus/config.yaml").write_text(
+            "journals_dir: journal_logs\n"
+        )
+        Path("journal_logs").mkdir()
+        monkeypatch.setattr(cli, "_now", FixedDate.now)
+        res = runner.invoke(cli.app, ["report", "--format", "html"])
+        out = re.sub(r"\x1b\[[0-9;]*m", "", res.output)
+        assert res.exit_code == 2
+        assert "Invalid value for '--format'" in out
+
+
+def test_report_negative_since():
+    with runner.isolated_filesystem():
+        res = runner.invoke(cli.app, ["report", "--since", "-1"])
+        out = re.sub(r"\x1b\[[0-9;]*m", "", res.output)
+        assert res.exit_code == 2
+        assert "Invalid value for '--since'" in out
+
+
+def test_report_format_case_insensitive(monkeypatch):
+    with runner.isolated_filesystem():
+        Path(".squirrelfocus").mkdir()
+        Path(".squirrelfocus/config.yaml").write_text(
+            "journals_dir: journal_logs\n"
+        )
+        jdir = Path("journal_logs")
+        jdir.mkdir()
+        make_entry(jdir / "2024-01-15.md", "2024-01-15", "bug1")
+        monkeypatch.setattr(cli, "_now", FixedDate.now)
+        res = runner.invoke(cli.app, ["report", "--format", "TXT"])
+        assert res.exit_code == 0
+        assert "bug1" in res.output
+        assert "###" not in res.output
+
+
+def test_report_missing_journal_dir(monkeypatch):
+    with runner.isolated_filesystem():
+        Path(".squirrelfocus").mkdir()
+        Path(".squirrelfocus/config.yaml").write_text(
+            "journals_dir: journal_logs\n"
+        )
+        monkeypatch.setattr(cli, "_now", FixedDate.now)
+        res = runner.invoke(cli.app, ["report"])
+        assert res.exit_code == 1
+        assert "No entries found." in res.output
+
+
+def test_report_empty_journal_dir(monkeypatch):
+    with runner.isolated_filesystem():
+        Path(".squirrelfocus").mkdir()
+        Path(".squirrelfocus/config.yaml").write_text(
+            "journals_dir: journal_logs\n"
+        )
+        Path("journal_logs").mkdir()
+        monkeypatch.setattr(cli, "_now", FixedDate.now)
+        res = runner.invoke(cli.app, ["report"])
+        assert res.exit_code == 1
+        assert "No entries found." in res.output


### PR DESCRIPTION
## Summary
- add `_now` helper for test-friendly time retrieval in the `report` command
- adjust report logic and tests to use the injectable time provider

## Testing
- `poetry run ruff check .`
- `poetry run black --check .`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b981596a5c83209799e635d1b90233