### PR TITLE
feat: skip invalid dates in report

### DIFF
--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -287,6 +287,22 @@ def doctor() -> None:
 
 
 @app.command()
+def report() -> None:
+    """List journal entry paths."""
+    cfg = load_cfg()
+    jdir = Path(cfg.get("journals_dir", "journal_logs"))
+    cutoff = datetime.now()
+    for path in sorted(jdir.glob("**/*.md")):
+        date_str = path.stem.split("-", 1)[0]
+        try:
+            dt = datetime.fromisoformat(date_str)
+        except ValueError:
+            continue
+        if dt < cutoff:
+            typer.echo(str(path))
+
+
+@app.command()
 def drop(text: str) -> None:
     """Append TEXT with a timestamp to ~/.squirrelfocus/acornlog.txt."""
     ensure_log_dir()


### PR DESCRIPTION
## Summary
- add report command and skip journal entries with invalid dates

## Testing
- `poetry run ruff check .`
- `poetry run black --check .`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9bf7b38148320a2d7727a1ea710f6