### PR TITLE
Handle full ISO date in report command

### DIFF
--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -293,7 +293,13 @@ def report() -> None:
     jdir = Path(cfg.get("journals_dir", "journal_logs"))
     cutoff = datetime.now()
     for path in sorted(jdir.glob("**/*.md")):
-        date_str = path.stem.split("-", 1)[0]
+        date_str = path.stem[:10]
+        if (
+            len(date_str) != 10
+            or date_str[4] != "-"
+            or date_str[7] != "-"
+        ):
+            continue
         try:
             dt = datetime.fromisoformat(date_str)
         except ValueError:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -224,3 +224,28 @@ def test_multiply_help():
     result = runner.invoke(cli.app, ["multiply", "--help"])
     assert result.exit_code == 0
     assert "product of A and B" in result.output
+
+
+def test_report_handles_dates(tmp_path, monkeypatch):
+    jdir = tmp_path / "journal_logs"
+    jdir.mkdir()
+    good1 = jdir / "2000-01-01-note.md"
+    good1.write_text("x")
+    good2 = jdir / "2000-06-15.md"
+    good2.write_text("x")
+    bad1 = jdir / "bad.md"
+    bad1.write_text("x")
+    bad2 = jdir / "2000-13-01.md"
+    bad2.write_text("x")
+    bad3 = jdir / "20000101.md"
+    bad3.write_text("x")
+    monkeypatch.setattr(
+        cli, "load_cfg", lambda: {"journals_dir": str(jdir)}
+    )
+    result = runner.invoke(cli.app, ["report"])
+    assert result.exit_code == 0
+    lines = result.output.strip().splitlines()
+    assert str(good1) in lines and str(good2) in lines
+    assert str(bad1) not in lines
+    assert str(bad2) not in lines
+    assert str(bad3) not in lines


### PR DESCRIPTION
## Summary
- parse full `YYYY-MM-DD` portion from journal filenames in `report`
- skip malformed journal names and add regression test

## Testing
- `pre-commit run --files cli/__init__.py` *(fails: .pre-commit-config.yaml is not a file)*
- `pytest tests/test_cli.py::test_report_handles_dates -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9c57728a88320a41886ba0ee674d4