### PR TITLE
test: check report ignores future-dated files

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -259,9 +259,7 @@ def test_report_ignores_future_files(tmp_path, monkeypatch):
     future_file.write_text("x")
     past_file = jdir / "2000-01-01.md"
     past_file.write_text("x")
-    monkeypatch.setattr(
-        cli, "load_cfg", lambda: {"journals_dir": str(jdir)}
-    )
+    monkeypatch.setattr(cli, "load_cfg", lambda: {"journals_dir": str(jdir)})
     result = runner.invoke(cli.app, ["report"])
     assert result.exit_code == 0
     lines = result.output.strip().splitlines()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+from datetime import date, timedelta
 from typer.testing import CliRunner
 import cli
 
@@ -247,3 +248,21 @@ def test_report_handles_dates(tmp_path, monkeypatch):
     assert str(bad1) not in lines
     assert str(bad2) not in lines
     assert str(bad3) not in lines
+
+
+def test_report_ignores_future_files(tmp_path, monkeypatch):
+    jdir = tmp_path / "journal_logs"
+    jdir.mkdir()
+    future = date.today() + timedelta(days=1)
+    future_file = jdir / f"{future.isoformat()}.md"
+    future_file.write_text("x")
+    past_file = jdir / "2000-01-01.md"
+    past_file.write_text("x")
+    monkeypatch.setattr(
+        cli, "load_cfg", lambda: {"journals_dir": str(jdir)}
+    )
+    result = runner.invoke(cli.app, ["report"])
+    assert result.exit_code == 0
+    lines = result.output.strip().splitlines()
+    assert str(past_file) in lines
+    assert str(future_file) not in lines

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -251,6 +251,7 @@ def test_report_handles_dates(tmp_path, monkeypatch):
 
 
 def test_report_ignores_future_files(tmp_path, monkeypatch):
+    runner = CliRunner()
     jdir = tmp_path / "journal_logs"
     jdir.mkdir()
     future = date.today() + timedelta(days=1)


### PR DESCRIPTION
## Summary
- import date utilities for test helpers
- ensure report skips future-dated journals

## Testing
- `pre-commit run --files tests/test_cli.py` (fails: .pre-commit-config.yaml is not a file)
- `pytest tests/test_cli.py::test_report*` (fails: not found)
- `pytest -k test_report tests/test_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9ceb51acc8320b2a525fbd7ab064e