### PR TITLE
Add CLI config validation and tests

### DIFF
--- a/cli/config.py
+++ b/cli/config.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+try:  # optional
+    import yaml
+    HAVE_YAML = True
+except Exception:  # pragma: no cover
+    yaml = None
+    HAVE_YAML = False
+
+CFG_PATH = Path('.squirrelfocus') / 'config.yaml'
+
+DEFAULTS = {
+    'journals_dir': 'journal_logs',
+    'entry_glob': '**/*.md',
+    'prefer_frontmatter': True,
+    'trailer_keys': ['fix', 'why', 'change', 'proof', 'ref'],
+    'summary_format': (
+        '### CI Triage\n'
+        '- **Fix:** {{fix}}\n'
+        '- **Why:** {{why}}\n'
+        '- **Change:** {{change}}\n'
+        '- **Proof:** {{proof}}\n'
+    ),
+}
+
+REQUIRED_KEYS: dict[str, type[Any]] = {
+    'journals_dir': str,
+    'entry_glob': str,
+    'prefer_frontmatter': bool,
+    'trailer_keys': list,
+    'summary_format': str,
+}
+
+
+def load() -> tuple[dict[str, Any], list[str]]:
+    """Return merged config and a list of problems."""
+    data: dict[str, Any] = {}
+    problems: list[str] = []
+    if HAVE_YAML and CFG_PATH.exists():
+        try:
+            with CFG_PATH.open('r', encoding='utf-8') as fh:
+                data = yaml.safe_load(fh) or {}
+        except Exception as exc:
+            problems.append(f'invalid YAML: {exc}')
+            data = {}
+    else:
+        data = {}
+    if not problems:
+        for key, typ in REQUIRED_KEYS.items():
+            if key not in data:
+                problems.append(f"missing '{key}'")
+            elif not isinstance(data[key], typ):
+                problems.append(
+                    f"'{key}' should be {typ.__name__}"
+                )
+    cfg = dict(DEFAULTS)
+    cfg.update({k: v for k, v in data.items() if v is not None})
+    return cfg, problems

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+from typer.testing import CliRunner
+import cli
+
+runner = CliRunner()
+
+VALID_CFG = (
+    "journals_dir: journal_logs\n"
+    "entry_glob: '**/*.md'\n"
+    "prefer_frontmatter: true\n"
+    "trailer_keys: [fix]\n"
+    "summary_format: hi\n"
+)
+
+
+def write_cfg(text: str) -> None:
+    Path('.squirrelfocus').mkdir(parents=True, exist_ok=True)
+    Path('.squirrelfocus/config.yaml').write_text(text)
+
+
+def test_startup_valid_config():
+    with runner.isolated_filesystem():
+        write_cfg(VALID_CFG)
+        result = runner.invoke(cli.app, ['hello'])
+        assert result.exit_code == 0
+        assert 'config:' not in result.output
+
+
+def test_startup_missing_key():
+    with runner.isolated_filesystem():
+        bad = VALID_CFG.replace("entry_glob: '**/*.md'\n", '')
+        write_cfg(bad)
+        result = runner.invoke(cli.app, ['hello'])
+        assert result.exit_code == 0
+        assert "missing 'entry_glob'" in result.output
+
+
+def test_startup_malformed_config():
+    with runner.isolated_filesystem():
+        write_cfg('journals_dir: x\nentry_glob: **/*.md\n')
+        result = runner.invoke(cli.app, ['hello'])
+        assert result.exit_code == 0
+        assert 'invalid YAML' in result.output

--- a/tests/test_cli_new.py
+++ b/tests/test_cli_new.py
@@ -10,6 +10,10 @@ def test_new_creates_entry():
         Path(".squirrelfocus").mkdir()
         Path(".squirrelfocus/config.yaml").write_text(
             "journals_dir: journal_logs\n"
+            "entry_glob: '**/*.md'\n"
+            "prefer_frontmatter: true\n"
+            "trailer_keys: [fix]\n"
+            "summary_format: x\n"
         )
         Path("templates").mkdir()
         Path("templates/sqf_fix.md").write_text("---\ntrailers:\n---\nbody\n")


### PR DESCRIPTION
## Summary
- define required configuration keys in new `cli/config.py`
- validate config on CLI startup and print hints for issues
- test valid, missing, and malformed config scenarios

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9f61f1d448320a3c47078b4381f4b