### PR TITLE
ci: remove redundant poetry lock step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,15 +81,6 @@ jobs:
               | tee -a "$GITHUB_STEP_SUMMARY"
           fi
 
-      - name: Poetry lock
-        if: steps.poetry.outputs.poetry_available == '1'
-        timeout-minutes: 15
-        shell: bash
-        run: |
-          set -euo pipefail
-          poetry --version
-          poetry lock --no-interaction
-
       - name: Install dependencies
         if: steps.poetry.outputs.poetry_available == '1'
         timeout-minutes: 15


### PR DESCRIPTION
## Summary
- remove Poetry lock step from CI workflow

## Testing
- `poetry run ruff check .`
- `poetry run black --check .`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9fd84ab9c8320a34ac0aca3db6149