### PR TITLE
chore(ci): use stable checkout in release workflow

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"


### PR DESCRIPTION
## Summary
- use actions/checkout v4 in release-publish workflow

## Testing
- `pytest -q`
- `./bin/act -e /tmp/tag_event.json -j publish -W .github/workflows/release-publish.yml -P ubuntu-24.04=ghcr.io/catthehacker/ubuntu:act-24.04 -s PYPI_API_TOKEN=fake` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68b9fe7358d08320b2ad24904785701a