### PR TITLE
Add startup config validation and tests

### DIFF
--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -10,13 +10,7 @@ import sys
 import openai
 import typer
 
-try:  # optional
-    import yaml
-
-    HAVE_YAML = True
-except Exception:  # pragma: no cover
-    yaml = None
-    HAVE_YAML = False
+from . import config as conf
 
 app = typer.Typer(
     help=(
@@ -26,24 +20,17 @@ app = typer.Typer(
     )
 )
 
+@app.callback(invoke_without_command=True)
+def _startup(_: typer.Context) -> None:
+    conf.validate(conf.read_cfg())
+
+
+load_cfg = conf.load_cfg
+
 LOG_DIR = Path.home() / ".squirrelfocus"
 LOG_FILE = LOG_DIR / "acornlog.txt"
 _BASE_PATH = Path(__file__).resolve().parents[1]
 PROMPT_FILE = _BASE_PATH / "codex" / "prompts" / "work_item_generator.md"
-
-CFG_PATH = Path(".squirrelfocus") / "config.yaml"
-DEF_CFG = {
-    "journals_dir": "journal_logs",
-    "trailer_keys": ["fix", "why", "change", "proof", "ref"],
-    "summary_format": (
-        "### CI Triage\n"
-        "- **Fix:** {{fix}}\n"
-        "- **Why:** {{why}}\n"
-        "- **Change:** {{change}}\n"
-        "- **Proof:** {{proof}}\n"
-    ),
-}
-
 
 def load_prompt() -> str:
     """Return the Codex work item prompt."""
@@ -53,20 +40,6 @@ def load_prompt() -> str:
 def ensure_log_dir() -> None:
     """Create the log directory if it does not exist."""
     LOG_DIR.mkdir(parents=True, exist_ok=True)
-
-
-def load_cfg() -> dict:
-    """Return configuration merged with defaults."""
-    if HAVE_YAML and CFG_PATH.exists():
-        try:
-            with CFG_PATH.open("r", encoding="utf-8") as fh:
-                data = yaml.safe_load(fh) or {}
-            out = dict(DEF_CFG)
-            out.update({k: v for k, v in data.items() if v is not None})
-            return out
-        except Exception:
-            pass
-    return dict(DEF_CFG)
 
 
 def slugify(text: str) -> str:
@@ -96,20 +69,23 @@ def init(
     created: list[Path] = []
 
     cfg_src = _BASE_PATH / ".squirrelfocus" / "config.yaml"
-    cfg_dst = CFG_PATH
+    cfg_dst = conf.CFG_PATH
     if force or not cfg_dst.exists():
         cfg_dst.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy(cfg_src, cfg_dst)
         created.append(cfg_dst)
 
-    cfg = load_cfg()
-    cfg["journals_dir"] = journals_dir
-    if HAVE_YAML:
+    data = load_cfg()
+    data["journals_dir"] = journals_dir
+    if conf.HAVE_YAML:
         cfg_dst.write_text(
-            yaml.safe_dump(cfg, sort_keys=False), encoding="utf-8"
+            conf.yaml.safe_dump(data, sort_keys=False),
+            encoding="utf-8",
         )
     else:
-        cfg_dst.write_text(f"journals_dir: {journals_dir}\n", encoding="utf-8")
+        cfg_dst.write_text(
+            f"journals_dir: {journals_dir}\n", encoding="utf-8"
+        )
 
     jdir = Path(journals_dir)
     if not jdir.exists():
@@ -200,8 +176,8 @@ def new(
         if val:
             fm["trailers"][key] = val
 
-    if HAVE_YAML:
-        fm_text = yaml.safe_dump(fm, sort_keys=False)
+    if conf.HAVE_YAML:
+        fm_text = conf.yaml.safe_dump(fm, sort_keys=False)
     else:
         lines = ["trailers:"]
         for k, v in fm["trailers"].items():
@@ -253,7 +229,7 @@ def doctor() -> None:
         typer.echo("pyyaml: present")
     except Exception:
         typer.echo("pyyaml: missing (pip install pyyaml)")
-    if CFG_PATH.exists():
+    if conf.CFG_PATH.exists():
         typer.echo("config: ok")
     else:
         typer.echo("config: missing (run 'sf init')")

--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -20,6 +20,7 @@ app = typer.Typer(
     )
 )
 
+
 @app.callback(invoke_without_command=True)
 def _startup(_: typer.Context) -> None:
     conf.validate(conf.read_cfg())
@@ -31,6 +32,7 @@ LOG_DIR = Path.home() / ".squirrelfocus"
 LOG_FILE = LOG_DIR / "acornlog.txt"
 _BASE_PATH = Path(__file__).resolve().parents[1]
 PROMPT_FILE = _BASE_PATH / "codex" / "prompts" / "work_item_generator.md"
+
 
 def load_prompt() -> str:
     """Return the Codex work item prompt."""
@@ -84,7 +86,8 @@ def init(
         )
     else:
         cfg_dst.write_text(
-            f"journals_dir: {journals_dir}\n", encoding="utf-8"
+            f"journals_dir: {journals_dir}\n",
+            encoding="utf-8",
         )
 
     jdir = Path(journals_dir)
@@ -252,8 +255,8 @@ def doctor() -> None:
         typer.echo("commit hook: ok")
     else:
         typer.echo(
-            "commit hook: missing (run 'scripts/install_hooks.sh' on Unix or "
-            "'scripts/install_hooks.ps1' on Windows)"
+            "commit hook: missing (run 'scripts/install_hooks.sh' on "
+            "Unix or 'scripts/install_hooks.ps1' on Windows)"
         )
         fail = True
     raise typer.Exit(code=1 if fail else 0)

--- a/cli/config.py
+++ b/cli/config.py
@@ -27,7 +27,7 @@ DEFAULTS: dict[str, Any] = {
     ),
 }
 
-REQUIRED: dict[str, type] = {
+REQUIRED_TYPES: dict[str, type] = {
     "journals_dir": str,
 }
 
@@ -63,7 +63,7 @@ def validate(data: dict[str, Any] | None) -> None:
     """Validate raw config data."""
     if data is None:
         return
-    for key, typ in REQUIRED.items():
+    for key, typ in REQUIRED_TYPES.items():
         if key not in data:
             typer.echo(f"Config missing '{key}'.")
             typer.echo(f"Example: {_example_line(key, DEFAULTS[key])}")
@@ -74,7 +74,7 @@ def validate(data: dict[str, Any] | None) -> None:
             typer.echo(f"Example: {_example_line(key, defval)}")
             raise typer.Exit(code=1)
     for key, defval in DEFAULTS.items():
-        if key in data and key not in REQUIRED:
+        if key in data and key not in REQUIRED_TYPES:
             if not isinstance(data[key], type(defval)):
                 typer.echo(f"Config key '{key}' malformed.")
                 typer.echo(f"Example: {_example_line(key, defval)}")

--- a/cli/config.py
+++ b/cli/config.py
@@ -31,6 +31,7 @@ REQUIRED_TYPES: dict[str, type] = {
     "journals_dir": str,
 }
 
+
 def read_cfg() -> dict[str, Any] | None:
     """Return raw config or None if file missing."""
     if not HAVE_YAML or not CFG_PATH.exists():
@@ -45,6 +46,7 @@ def read_cfg() -> dict[str, Any] | None:
         typer.echo(f"Could not read config: {err}")
         raise typer.Exit(code=1)
 
+
 def load_cfg(data: dict[str, Any] | None = None) -> dict[str, Any]:
     """Return configuration merged with defaults."""
     if data is None:
@@ -53,11 +55,13 @@ def load_cfg(data: dict[str, Any] | None = None) -> dict[str, Any]:
     cfg.update({k: v for k, v in data.items() if v is not None})
     return cfg
 
+
 def _example_line(key: str, value: Any) -> str:
     if isinstance(value, list):
         inner = ", ".join(str(v) for v in value)
         return f"{key}: [{inner}]"
     return f"{key}: {value}"
+
 
 def validate(data: dict[str, Any] | None) -> None:
     """Validate raw config data."""

--- a/cli/config.py
+++ b/cli/config.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import typer
+
+try:  # optional
+    import yaml
+
+    HAVE_YAML = True
+except Exception:  # pragma: no cover
+    yaml = None
+    HAVE_YAML = False
+
+CFG_PATH = Path(".squirrelfocus") / "config.yaml"
+
+DEFAULTS: dict[str, Any] = {
+    "journals_dir": "journal_logs",
+    "trailer_keys": ["fix", "why", "change", "proof", "ref"],
+    "summary_format": (
+        "### CI Triage\n"
+        "- **Fix:** {{fix}}\n"
+        "- **Why:** {{why}}\n"
+        "- **Change:** {{change}}\n"
+        "- **Proof:** {{proof}}\n"
+    ),
+}
+
+REQUIRED: dict[str, type] = {
+    "journals_dir": str,
+}
+
+def read_cfg() -> dict[str, Any] | None:
+    """Return raw config or None if file missing."""
+    if not HAVE_YAML or not CFG_PATH.exists():
+        return None
+    try:
+        with CFG_PATH.open("r", encoding="utf-8") as fh:
+            return yaml.safe_load(fh) or {}
+    except Exception:
+        return {}
+
+def load_cfg(data: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Return configuration merged with defaults."""
+    if data is None:
+        data = read_cfg() or {}
+    cfg: dict[str, Any] = dict(DEFAULTS)
+    cfg.update({k: v for k, v in data.items() if v is not None})
+    return cfg
+
+def _example_line(key: str, value: Any) -> str:
+    if isinstance(value, list):
+        inner = ", ".join(str(v) for v in value)
+        return f"{key}: [{inner}]"
+    return f"{key}: {value}"
+
+def validate(data: dict[str, Any] | None) -> None:
+    """Validate raw config data."""
+    if data is None:
+        return
+    for key, typ in REQUIRED.items():
+        if key not in data:
+            typer.echo(f"Config missing '{key}'.")
+            typer.echo(f"Example: {_example_line(key, DEFAULTS[key])}")
+            raise typer.Exit(code=1)
+    for key, defval in DEFAULTS.items():
+        if key in data and not isinstance(data[key], type(defval)):
+            typer.echo(f"Config key '{key}' malformed.")
+            typer.echo(f"Example: {_example_line(key, defval)}")
+            raise typer.Exit(code=1)

--- a/cli/config.py
+++ b/cli/config.py
@@ -64,8 +64,17 @@ def validate(data: dict[str, Any] | None) -> None:
             typer.echo(f"Config missing '{key}'.")
             typer.echo(f"Example: {_example_line(key, DEFAULTS[key])}")
             raise typer.Exit(code=1)
+        if not isinstance(data[key], typ):
+            typer.echo(f"Config key '{key}' malformed.")
+            defval = DEFAULTS.get(key, typ())
+            typer.echo(f"Example: {_example_line(key, defval)}")
+            raise typer.Exit(code=1)
     for key, defval in DEFAULTS.items():
-        if key in data and not isinstance(data[key], type(defval)):
+        if (
+            key in data
+            and key not in REQUIRED
+            and not isinstance(data[key], type(defval))
+        ):
             typer.echo(f"Config key '{key}' malformed.")
             typer.echo(f"Example: {_example_line(key, defval)}")
             raise typer.Exit(code=1)

--- a/cli/config.py
+++ b/cli/config.py
@@ -70,11 +70,14 @@ def validate(data: dict[str, Any] | None) -> None:
             typer.echo(f"Example: {_example_line(key, defval)}")
             raise typer.Exit(code=1)
     for key, defval in DEFAULTS.items():
-        if (
-            key in data
-            and key not in REQUIRED
-            and not isinstance(data[key], type(defval))
-        ):
-            typer.echo(f"Config key '{key}' malformed.")
-            typer.echo(f"Example: {_example_line(key, defval)}")
-            raise typer.Exit(code=1)
+        if key in data and key not in REQUIRED:
+            if not isinstance(data[key], type(defval)):
+                typer.echo(f"Config key '{key}' malformed.")
+                typer.echo(f"Example: {_example_line(key, defval)}")
+                raise typer.Exit(code=1)
+            if key == "trailer_keys" and not all(
+                isinstance(v, str) for v in data[key]
+            ):
+                typer.echo("Config key 'trailer_keys' malformed.")
+                typer.echo(f"Example: {_example_line(key, defval)}")
+                raise typer.Exit(code=1)

--- a/cli/config.py
+++ b/cli/config.py
@@ -38,8 +38,12 @@ def read_cfg() -> dict[str, Any] | None:
     try:
         with CFG_PATH.open("r", encoding="utf-8") as fh:
             return yaml.safe_load(fh) or {}
-    except Exception:
-        return {}
+    except yaml.YAMLError as err:
+        typer.echo(f"Failed to parse config: {err}")
+        raise typer.Exit(code=1)
+    except OSError as err:
+        typer.echo(f"Could not read config: {err}")
+        raise typer.Exit(code=1)
 
 def load_cfg(data: dict[str, Any] | None = None) -> dict[str, Any]:
     """Return configuration merged with defaults."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,7 @@ import cli
 runner = CliRunner()
 
 def _write(text: str) -> None:
-    Path('.squirrelfocus').mkdir()
+    Path('.squirrelfocus').mkdir(exist_ok=True)
     Path('.squirrelfocus/config.yaml').write_text(text)
 
 def test_valid_config_allows_run():
@@ -40,3 +40,15 @@ def test_malformed_key_shows_example():
         assert result.exit_code != 0
         assert 'trailer_keys' in result.output
         assert 'trailer_keys: [fix, why, change, proof, ref]' in result.output
+
+def test_required_key_malformed_shows_example():
+    with runner.isolated_filesystem():
+        _write(
+            'journals_dir: [logs]\n'
+            'trailer_keys: [fix]\n'
+            "summary_format: 'x'\n"
+        )
+        result = runner.invoke(cli.app, ['hello'])
+        assert result.exit_code != 0
+        assert 'journals_dir' in result.output
+        assert 'journals_dir: journal_logs' in result.output

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -52,3 +52,15 @@ def test_required_key_malformed_shows_example():
         assert result.exit_code != 0
         assert 'journals_dir' in result.output
         assert 'journals_dir: journal_logs' in result.output
+
+def test_trailer_keys_elements_must_be_strings():
+    with runner.isolated_filesystem():
+        _write(
+            'journals_dir: logs\n'
+            'trailer_keys: [fix, 1]\n'
+            "summary_format: 'x'\n"
+        )
+        result = runner.invoke(cli.app, ['hello'])
+        assert result.exit_code != 0
+        assert 'trailer_keys' in result.output
+        assert 'trailer_keys: [fix, why, change, proof, ref]' in result.output

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,7 @@ runner = CliRunner()
 
 
 def _cfg_path() -> Path:
-    path = Path('.squirrelfocus') / 'config.yaml'
+    path = Path(".squirrelfocus") / "config.yaml"
     cli.conf.CFG_PATH = path
     return path
 
@@ -16,72 +16,74 @@ def _write(text: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text)
 
+
 def test_valid_config_allows_run():
     with runner.isolated_filesystem():
         cfg = (
-            'journals_dir: logs\n'
-            'trailer_keys: [fix, why]\n'
+            "journals_dir: logs\n"
+            "trailer_keys: [fix, why]\n"
             "summary_format: 'x'\n"
         )
         _write(cfg)
         _write(cfg)
-        result = runner.invoke(cli.app, ['hello'])
+        result = runner.invoke(cli.app, ["hello"])
         assert result.exit_code == 0
+
 
 def test_missing_key_shows_example():
     with runner.isolated_filesystem():
-        _write(
-            'trailer_keys: [fix]\n'
-            "summary_format: 'x'\n"
-        )
-        result = runner.invoke(cli.app, ['hello'])
+        _write("trailer_keys: [fix]\n" "summary_format: 'x'\n")
+        result = runner.invoke(cli.app, ["hello"])
         assert result.exit_code != 0
-        assert 'journals_dir' in result.output
-        assert 'journals_dir: journal_logs' in result.output
+        assert "journals_dir" in result.output
+        assert "journals_dir: journal_logs" in result.output
+
 
 def test_malformed_key_shows_example():
     with runner.isolated_filesystem():
         _write(
-            'journals_dir: logs\n'
-            'trailer_keys: bad\n'
+            "journals_dir: logs\n"
+            "trailer_keys: bad\n"
             "summary_format: 'x'\n"
         )
-        result = runner.invoke(cli.app, ['hello'])
+        result = runner.invoke(cli.app, ["hello"])
         assert result.exit_code != 0
-        assert 'trailer_keys' in result.output
-        assert 'trailer_keys: [fix, why, change, proof, ref]' in result.output
+        assert "trailer_keys" in result.output
+        assert "trailer_keys: [fix, why, change, proof, ref]" in result.output
+
 
 def test_required_key_malformed_shows_example():
     with runner.isolated_filesystem():
         _write(
-            'journals_dir: [logs]\n'
-            'trailer_keys: [fix]\n'
+            "journals_dir: [logs]\n"
+            "trailer_keys: [fix]\n"
             "summary_format: 'x'\n"
         )
-        result = runner.invoke(cli.app, ['hello'])
+        result = runner.invoke(cli.app, ["hello"])
         assert result.exit_code != 0
-        assert 'journals_dir' in result.output
-        assert 'journals_dir: journal_logs' in result.output
+        assert "journals_dir" in result.output
+        assert "journals_dir: journal_logs" in result.output
+
 
 def test_trailer_keys_elements_must_be_strings():
     with runner.isolated_filesystem():
         _write(
-            'journals_dir: logs\n'
-            'trailer_keys: [fix, 1]\n'
+            "journals_dir: logs\n"
+            "trailer_keys: [fix, 1]\n"
             "summary_format: 'x'\n"
         )
-        result = runner.invoke(cli.app, ['hello'])
+        result = runner.invoke(cli.app, ["hello"])
         assert result.exit_code != 0
-        assert 'trailer_keys' in result.output
-        assert 'trailer_keys: [fix, why, change, proof, ref]' in result.output
+        assert "trailer_keys" in result.output
+        assert "trailer_keys: [fix, why, change, proof, ref]" in result.output
 
 
 def test_malformed_yaml_shows_error():
     with runner.isolated_filesystem():
-        _write('journals_dir: [\n')
-        result = runner.invoke(cli.app, ['hello'])
+        _write("journals_dir: [\n")
+        result = runner.invoke(cli.app, ["hello"])
         assert result.exit_code != 0
-        assert 'Failed to parse config' in result.output
+        assert "Failed to parse config" in result.output
 
 
 def test_unreadable_config_shows_error():
@@ -89,6 +91,6 @@ def test_unreadable_config_shows_error():
         path = _cfg_path()
         path.parent.mkdir(exist_ok=True)
         path.mkdir()
-        result = runner.invoke(cli.app, ['hello'])
+        result = runner.invoke(cli.app, ["hello"])
         assert result.exit_code != 0
-        assert 'Could not read config' in result.output
+        assert "Could not read config" in result.output

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,16 +5,19 @@ import cli
 runner = CliRunner()
 
 def _write(text: str) -> None:
-    Path('.squirrelfocus').mkdir(exist_ok=True)
-    Path('.squirrelfocus/config.yaml').write_text(text)
+    cfg = Path('.squirrelfocus')
+    cfg.mkdir(parents=True, exist_ok=True)
+    (cfg / 'config.yaml').write_text(text)
 
 def test_valid_config_allows_run():
     with runner.isolated_filesystem():
-        _write(
+        cfg = (
             'journals_dir: logs\n'
             'trailer_keys: [fix, why]\n'
             "summary_format: 'x'\n"
         )
+        _write(cfg)
+        _write(cfg)
         result = runner.invoke(cli.app, ['hello'])
         assert result.exit_code == 0
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -64,3 +64,21 @@ def test_trailer_keys_elements_must_be_strings():
         assert result.exit_code != 0
         assert 'trailer_keys' in result.output
         assert 'trailer_keys: [fix, why, change, proof, ref]' in result.output
+
+
+def test_malformed_yaml_shows_error():
+    with runner.isolated_filesystem():
+        _write('journals_dir: [\n')
+        result = runner.invoke(cli.app, ['hello'])
+        assert result.exit_code != 0
+        assert 'Failed to parse config' in result.output
+
+
+def test_unreadable_config_shows_error():
+    with runner.isolated_filesystem():
+        path = Path('.squirrelfocus') / 'config.yaml'
+        path.parent.mkdir(exist_ok=True)
+        path.mkdir()
+        result = runner.invoke(cli.app, ['hello'])
+        assert result.exit_code != 0
+        assert 'Could not read config' in result.output

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,10 +4,17 @@ import cli
 
 runner = CliRunner()
 
+
+def _cfg_path() -> Path:
+    path = Path('.squirrelfocus') / 'config.yaml'
+    cli.conf.CFG_PATH = path
+    return path
+
+
 def _write(text: str) -> None:
-    cfg = Path('.squirrelfocus')
-    cfg.mkdir(parents=True, exist_ok=True)
-    (cfg / 'config.yaml').write_text(text)
+    path = _cfg_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
 
 def test_valid_config_allows_run():
     with runner.isolated_filesystem():
@@ -79,7 +86,7 @@ def test_malformed_yaml_shows_error():
 
 def test_unreadable_config_shows_error():
     with runner.isolated_filesystem():
-        path = Path('.squirrelfocus') / 'config.yaml'
+        path = _cfg_path()
         path.parent.mkdir(exist_ok=True)
         path.mkdir()
         result = runner.invoke(cli.app, ['hello'])


### PR DESCRIPTION
## Summary
- centralize CLI config defaults and required keys
- validate configuration on startup with helpful examples
- add tests for valid, missing, and malformed configs

## Testing
- `python -m ruff check squirrelfocus/cli/config.py squirrelfocus/cli/__init__.py squirrelfocus/tests/test_config.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba072d360c8320a32380812eb8e9ab