### PR TITLE
Comment CI summary only for triaged pull requests

### DIFF
--- a/.github/workflows/ci-summary.yml
+++ b/.github/workflows/ci-summary.yml
@@ -31,3 +31,10 @@ jobs:
           else
             echo "No summary available" >> $GITHUB_STEP_SUMMARY
           fi
+      - name: Comment CI Summary
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const post = require('./scripts/post_triage_comment.js');
+            await post({github, context, core});

--- a/scripts/post_triage_comment.js
+++ b/scripts/post_triage_comment.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+
+module.exports = async function (
+  {github, context, core}, path = 'summary.md'
+) {
+  const pr = context.payload.pull_request;
+  const labels = pr?.labels?.map(l => l.name) || [];
+  if (!labels.includes('sqf:triage')) {
+    core.info('sqf:triage label missing');
+    return false;
+  }
+  let body = '';
+  try {
+    body = fs.readFileSync(path, 'utf8').trim();
+  } catch {
+    core.info(`missing ${path}`);
+    return false;
+  }
+  if (!body) {
+    core.info('empty summary');
+    return false;
+  }
+  await github.rest.issues.createComment({
+    issue_number: pr.number,
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    body
+  });
+  return true;
+};

--- a/tests/test_post_triage_comment.py
+++ b/tests/test_post_triage_comment.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+
+
+def test_skip_without_label(tmp_path: Path):
+    root = Path(__file__).resolve().parents[1]
+    mod = root / "scripts" / "post_triage_comment.js"
+    summ = tmp_path / "summary.md"
+    summ.write_text("hi")
+    mod_path = json.dumps(str(mod))
+    sum_path = json.dumps(str(summ))
+    js = """
+const fn = require({mod_path});
+const ctx = {{
+  payload: {{pull_request: {{number: 1, labels: []}}}},
+  repo: {{owner: 'o', repo: 'r'}}
+}};
+let called = false;
+const github = {{
+  rest: {{issues: {{createComment: () => {{called = true;}}}}}}
+}};
+const core = {{info: () => {{}}}};
+fn({{github, context: ctx, core}}, {sum_path}).then((r) => {{
+  if (!called && !r) process.exit(0);
+  process.exit(1);
+}});
+""".format(mod_path=mod_path, sum_path=sum_path)
+    proc = subprocess.run(["node", "-e", js])
+    assert proc.returncode == 0

--- a/tests/test_post_triage_comment.py
+++ b/tests/test_post_triage_comment.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 import subprocess
+import textwrap
+from string import Template
 
 
 def test_skip_without_label(tmp_path: Path):
@@ -12,21 +14,26 @@ def test_skip_without_label(tmp_path: Path):
     summ.write_text("hi")
     mod_path = json.dumps(str(mod))
     sum_path = json.dumps(str(summ))
-    js = """
-const fn = require({mod_path});
-const ctx = {{
-  payload: {{pull_request: {{number: 1, labels: []}}}},
-  repo: {{owner: 'o', repo: 'r'}}
-}};
-let called = false;
-const github = {{
-  rest: {{issues: {{createComment: () => {{called = true;}}}}}}
-}};
-const core = {{info: () => {{}}}};
-fn({{github, context: ctx, core}}, {sum_path}).then((r) => {{
-  if (!called && !r) process.exit(0);
-  process.exit(1);
-}});
-""".format(mod_path=mod_path, sum_path=sum_path)
+    tpl = Template(
+        textwrap.dedent(
+            """
+            const fn = require($mod_path);
+            const ctx = {
+              payload: {pull_request: {number: 1, labels: []}},
+              repo: {owner: 'o', repo: 'r'}
+            };
+            let called = false;
+            const github = {
+              rest: {issues: {createComment: () => {called = true;}}}
+            };
+            const core = {info: () => {}};
+            fn({github, context: ctx, core}, $sum_path).then((r) => {
+              if (!called && !r) process.exit(0);
+              process.exit(1);
+            });
+            """
+        )
+    )
+    js = tpl.substitute(mod_path=mod_path, sum_path=sum_path)
     proc = subprocess.run(["node", "-e", js])
     assert proc.returncode == 0


### PR DESCRIPTION
## Summary
- post CI summary comment only if PR carries `sqf:triage` label
- add script used by `actions/github-script` for label check and comment
- test that comment is skipped when label is missing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba25b7a6f08320937e47d043fba985