### PR TITLE
Document CLI config keys and extend config tests

### DIFF
--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -11,6 +11,22 @@ The CLI offers a few flags in addition to its subcommands:
 - `--show-completion` prints the completion script to standard output.
 - `--help` displays usage information for the selected command.
 
+## Configuration
+
+Settings are read from `.squirrelfocus/config.yaml`.
+
+Required keys:
+
+- `journals_dir` (str) journal directory.
+
+Optional keys:
+
+- `trailer_keys` (list[str]) commit trailer names.
+- `summary_format` (str) template for previews.
+
+Extra keys are ignored. A missing or malformed `journals_dir`
+causes an error.
+
 ## init
 
 Set up the current directory for SquirrelFocus.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,6 +30,18 @@ def test_valid_config_allows_run():
         assert result.exit_code == 0
 
 
+def test_extra_key_is_ignored():
+    with runner.isolated_filesystem():
+        _write(
+            "journals_dir: logs\n"
+            "trailer_keys: [fix]\n"
+            "summary_format: 'x'\n"
+            "extra: 1\n"
+        )
+        result = runner.invoke(cli.app, ["hello"])
+        assert result.exit_code == 0
+
+
 def test_missing_key_shows_example():
     with runner.isolated_filesystem():
         _write("trailer_keys: [fix]\n" "summary_format: 'x'\n")


### PR DESCRIPTION
## Summary
- document required config keys and their types in CLI reference
- add test for extra config key to ensure it is ignored

## Testing
- `poetry run black tests/test_config.py`
- `poetry run ruff check .`
- `poetry install --no-root`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba49d966a0832099944432b621a96c