### PR TITLE
Clarify config keys in CLI docs

### DIFF
--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -17,15 +17,17 @@ Settings are read from `.squirrelfocus/config.yaml`.
 
 Required keys:
 
-- `journals_dir` (str) journal directory.
+- `journals_dir` (str): path for journal entries.
 
 Optional keys:
 
-- `trailer_keys` (list[str]) commit trailer names.
-- `summary_format` (str) template for previews.
+- `trailer_keys` (list[str]): commit trailer names. Defaults to
+  `[fix, why, change, proof, ref]`. Elements must be strings.
+- `summary_format` (str): preview template. Defaults to a multi-line
+  summary.
 
-Extra keys are ignored. A missing or malformed `journals_dir`
-causes an error.
+Unknown keys are ignored. Missing or malformed keys show an example
+with the expected type.
 
 ## init
 


### PR DESCRIPTION
## Summary
- clarify configuration keys and types in CLI reference
- verify tests cover missing, malformed, and extra config fields

## Testing
- `poetry run ruff check .`
- `poetry run black --check .`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba5607af70832093e01c248018b3f8