### PR TITLE
docs: describe new flags for new command

### DIFF
--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -54,6 +54,14 @@ trailers.
 poetry run sf new --fix bug --why "to reproduce"
 ```
 
+Options:
+
+- `--fix TEXT` describe the bug or issue addressed.
+- `--why TEXT` explain the motivation for the change.
+- `--change TEXT` summarize what was modified.
+- `--proof TEXT` describe how the change was verified.
+- `--ref TEXT` link to related issues or resources.
+
 ## preview
 
 Render the latest journal entry. The default format is `summary`. Supported

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -56,11 +56,11 @@ poetry run sf new --fix bug --why "to reproduce"
 
 Options:
 
-- `--fix TEXT` describe the bug or issue addressed.
-- `--why TEXT` explain the motivation for the change.
-- `--change TEXT` summarize what was modified.
-- `--proof TEXT` describe how the change was verified.
-- `--ref TEXT` link to related issues or resources.
+- `--fix TEXT` Describe the bug or issue addressed.
+- `--why TEXT` Explain the motivation for the change.
+- `--change TEXT` Summarize what was modified.
+- `--proof TEXT` Describe how the change was verified.
+- `--ref TEXT` Link to related issues or resources.
 
 ## preview
 


### PR DESCRIPTION
## Summary
- document --fix, --why, --change, --proof, and --ref flags for `sf new`

## Testing
- `pytest` *(fails: tests/test_config.py::test_missing_key_shows_example et al.)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5984da548320a4008c1e7c1781e2