### PR TITLE
test: cover triage comment summary cases

### DIFF
--- a/tests/test_post_triage_comment.py
+++ b/tests/test_post_triage_comment.py
@@ -37,3 +37,110 @@ def test_skip_without_label(tmp_path: Path):
     js = tpl.substitute(mod_path=mod_path, sum_path=sum_path)
     proc = subprocess.run(["node", "-e", js])
     assert proc.returncode == 0
+
+
+def test_comment_with_label_and_summary(tmp_path: Path):
+    root = Path(__file__).resolve().parents[1]
+    mod = root / "scripts" / "post_triage_comment.js"
+    summ = tmp_path / "summary.md"
+    summ.write_text("hi")
+    mod_path = json.dumps(str(mod))
+    sum_path = json.dumps(str(summ))
+    tpl = Template(
+        textwrap.dedent(
+            """
+            const fn = require($mod_path);
+            const ctx = {
+              payload: {
+                pull_request: {
+                  number: 1, labels: [{name: 'sqf:triage'}]
+                }
+              },
+              repo: {owner: 'o', repo: 'r'}
+            };
+            let called = false;
+            const github = {
+              rest: {issues: {createComment: () => {called = true;}}}
+            };
+            const core = {info: () => {}};
+            fn({github, context: ctx, core}, $sum_path).then((r) => {
+              if (called && r) process.exit(0);
+              process.exit(1);
+            });
+            """
+        )
+    )
+    js = tpl.substitute(mod_path=mod_path, sum_path=sum_path)
+    proc = subprocess.run(["node", "-e", js])
+    assert proc.returncode == 0
+
+
+def test_skip_with_label_missing_summary(tmp_path: Path):
+    root = Path(__file__).resolve().parents[1]
+    mod = root / "scripts" / "post_triage_comment.js"
+    mod_path = json.dumps(str(mod))
+    # Pass a non-existent summary file to simulate the missing summary case.
+    sum_path = json.dumps(str(tmp_path / "summary.md"))
+    tpl = Template(
+        textwrap.dedent(
+            """
+            const fn = require($mod_path);
+            const ctx = {
+              payload: {
+                pull_request: {
+                  number: 1, labels: [{name: 'sqf:triage'}]
+                }
+              },
+              repo: {owner: 'o', repo: 'r'}
+            };
+            let called = false;
+            const github = {
+              rest: {issues: {createComment: () => {called = true;}}}
+            };
+            const core = {info: () => {}};
+            fn({github, context: ctx, core}, $sum_path).then((r) => {
+              if (!called && !r) process.exit(0);
+              process.exit(1);
+            });
+            """
+        )
+    )
+    js = tpl.substitute(mod_path=mod_path, sum_path=sum_path)
+    proc = subprocess.run(["node", "-e", js])
+    assert proc.returncode == 0
+
+
+def test_skip_with_label_empty_summary(tmp_path: Path):
+    root = Path(__file__).resolve().parents[1]
+    mod = root / "scripts" / "post_triage_comment.js"
+    summ = tmp_path / "summary.md"
+    summ.write_text("")
+    mod_path = json.dumps(str(mod))
+    sum_path = json.dumps(str(summ))
+    tpl = Template(
+        textwrap.dedent(
+            """
+            const fn = require($mod_path);
+            const ctx = {
+              payload: {
+                pull_request: {
+                  number: 1, labels: [{name: 'sqf:triage'}]
+                }
+              },
+              repo: {owner: 'o', repo: 'r'}
+            };
+            let called = false;
+            const github = {
+              rest: {issues: {createComment: () => {called = true;}}}
+            };
+            const core = {info: () => {}};
+            fn({github, context: ctx, core}, $sum_path).then((r) => {
+              if (!called && !r) process.exit(0);
+              process.exit(1);
+            });
+            """
+        )
+    )
+    js = tpl.substitute(mod_path=mod_path, sum_path=sum_path)
+    proc = subprocess.run(["node", "-e", js])
+    assert proc.returncode == 0


### PR DESCRIPTION
## Summary
- verify triage comment posts when summary exists
- ensure no comment when summary file missing or empty

## Testing
- `poetry run ruff check .`
- `poetry run black --check .`
- `poetry run pytest tests/test_post_triage_comment.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba638db5588320a026927ad29ec89d